### PR TITLE
fix(renovate): Renovate not tracking `rook-ceph` Kustomize remote resources

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,5 +25,12 @@
         "managerFilePatterns": [
             "/\\.yaml$/"
         ]
-    }
+    },
+    "regexManagers": [
+        {
+            "fileMatch": ["/(^|/)kustomization\\.ya?ml$/"],
+            "matchStrings": ["https://raw\\.githubusercontent\\.com/(?<depName>[^/]*/[^/]*)/(?<currentValue>.*?)/"],
+            "datasourceTemplate": "github-tags"
+        }
+    ]
 }


### PR DESCRIPTION
Closes #3 