### PR TITLE
fix: harden homelab deployment guardrails

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,9 +16,11 @@ concurrency:
 
 jobs:
   deploy:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     environment: prod
     env:
+      TF_IN_AUTOMATION: "1"
       ANSIBLE_CONFIG: infra/ansible/ansible.cfg
       PROXMOX_ENDPOINT: ${{ secrets.PROXMOX_ENDPOINT }}
       PROXMOX_API_TOKEN: ${{ secrets.PROXMOX_API_TOKEN }}

--- a/apps/dns/acme/renew-adguard-cert.sh
+++ b/apps/dns/acme/renew-adguard-cert.sh
@@ -34,4 +34,9 @@ chown root:"${TLS_GROUP}" "${CERT_DIR}" "${CERT_DIR}/fullchain.pem" "${CERT_DIR}
 chmod 0750 "${CERT_DIR}"
 chmod 0640 "${CERT_DIR}/fullchain.pem" "${CERT_DIR}/privkey.pem"
 
-rc-service adguardhome restart || true
+if [ -x /etc/init.d/adguardhome ]; then
+  rc-service adguardhome restart
+  rc-service adguardhome status
+else
+  echo "AdGuard Home service is not installed yet; certificate staged"
+fi

--- a/infra/ansible/inventory/prod/group_vars/downloads.yml
+++ b/infra/ansible/inventory/prod/group_vars/downloads.yml
@@ -2,7 +2,7 @@ downloads_mount_path: /downloads
 downloads_complete_path: /downloads/complete
 downloads_incomplete_path: /downloads/incomplete
 proton_wg_interface: wg-proton
-proton_server_list_url: https://raw.githubusercontent.com/qdm12/gluetun-servers/refs/heads/main/pkg/servers/protonvpn.json
+proton_server_list_url: https://raw.githubusercontent.com/qdm12/gluetun-servers/14277e92ce8291eb4515cd9af0dfad383a23f145/pkg/servers/protonvpn.json
 proton_server_country: Japan
 proton_port_forward_only: true
 proton_wireguard_address: 10.2.0.2/32

--- a/infra/ansible/inventory/prod/group_vars/edge.yml
+++ b/infra/ansible/inventory/prod/group_vars/edge.yml
@@ -2,7 +2,7 @@
 caddy_version: "v2.11.4"
 # renovate: datasource=github-releases depName=caddyserver/xcaddy versioning=semver extractVersion=^v(?<version>.*)$
 xcaddy_version: "v0.4.5"
-caddy_cloudflare_module: "github.com/caddy-dns/cloudflare"
+caddy_cloudflare_module: "github.com/caddy-dns/cloudflare@v0.2.4"
 caddy_config_path: /etc/caddy/Caddyfile
 caddy_env_path: /etc/conf.d/caddy
 caddy_data_dir: /var/lib/caddy

--- a/infra/ansible/roles/adguard/handlers/main.yml
+++ b/infra/ansible/roles/adguard/handlers/main.yml
@@ -3,3 +3,8 @@
   ansible.builtin.service:
     name: adguardhome
     state: restarted
+
+- name: Restart adguard nftables
+  ansible.builtin.service:
+    name: nftables
+    state: restarted

--- a/infra/ansible/roles/adguard/tasks/main.yml
+++ b/infra/ansible/roles/adguard/tasks/main.yml
@@ -8,6 +8,7 @@
       - apache2-utils
       - ldns
       - libcap
+      - nftables
       - tar
     update_cache: true
     state: present
@@ -75,6 +76,21 @@
     cmd: "setcap cap_net_bind_service=+ep {{ adguard_install_dir }}/AdGuardHome"
   changed_when: false
 
+- name: Install AdGuard nftables config
+  ansible.builtin.template:
+    src: nftables.conf.j2
+    dest: /etc/nftables.conf
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart adguard nftables
+
+- name: Enable AdGuard nftables
+  ansible.builtin.service:
+    name: nftables
+    enabled: true
+    state: started
+
 - name: Require AdGuard admin credentials
   ansible.builtin.assert:
     that:
@@ -86,7 +102,56 @@
     fail_msg: adguard_admin_username and adguard_admin_password must be provided; the role hashes the password before writing AdGuard config.
   no_log: true
 
-- name: Hash AdGuard admin password
+- name: Read existing AdGuard admin password hash
+  ansible.builtin.command:
+    argv:
+      - python3
+      - -c
+      - |
+        from pathlib import Path
+        import sys
+
+        path = Path(sys.argv[1])
+        username = sys.argv[2]
+        if not path.exists():
+            print("")
+            raise SystemExit(0)
+
+        lines = path.read_text(encoding="utf-8").splitlines()
+        for index, line in enumerate(lines):
+            if line.strip() == f'- name: "{username}"':
+                for candidate in lines[index + 1 : index + 4]:
+                    stripped = candidate.strip()
+                    if stripped.startswith("password:"):
+                        print(stripped.split(":", 1)[1].strip().strip('"'))
+                        raise SystemExit(0)
+        print("")
+      - "{{ adguard_conf_dir }}/AdGuardHome.yaml"
+      - "{{ adguard_admin_username }}"
+  register: adguard_existing_admin_hash
+  changed_when: false
+  no_log: true
+
+- name: Verify existing AdGuard admin password hash
+  ansible.builtin.shell: |
+    set -eu
+    tmp="$(mktemp)"
+    trap 'rm -f "${tmp}"' EXIT
+    printf '%s:%s\n' "${ADGUARD_ADMIN_USERNAME}" "${ADGUARD_ADMIN_HASH}" > "${tmp}"
+    htpasswd -vb "${tmp}" "${ADGUARD_ADMIN_USERNAME}" "${ADGUARD_ADMIN_PASSWORD}" >/dev/null
+  args:
+    executable: /bin/sh
+  environment:
+    ADGUARD_ADMIN_USERNAME: "{{ adguard_admin_username }}"
+    ADGUARD_ADMIN_HASH: "{{ adguard_existing_admin_hash.stdout }}"
+    ADGUARD_ADMIN_PASSWORD: "{{ adguard_admin_password }}"
+  register: adguard_existing_admin_hash_verify
+  changed_when: false
+  failed_when: false
+  no_log: true
+  when: adguard_existing_admin_hash.stdout | length > 0
+
+- name: Hash AdGuard admin password when rotation is required
   ansible.builtin.command:
     argv:
       - htpasswd
@@ -100,10 +165,14 @@
   register: adguard_admin_htpasswd
   changed_when: false
   no_log: true
+  when: adguard_existing_admin_hash_verify.rc | default(1) != 0
 
 - name: Set AdGuard admin password hash
   ansible.builtin.set_fact:
-    adguard_admin_password_hash: "{{ adguard_admin_htpasswd.stdout.split(':', 1)[1] }}"
+    adguard_admin_password_hash: >-
+      {{ adguard_existing_admin_hash.stdout
+      if (adguard_existing_admin_hash_verify.rc | default(1)) == 0
+      else adguard_admin_htpasswd.stdout.split(':', 1)[1] }}
   no_log: true
 
 - name: Install baseline AdGuard config when no migrated config exists

--- a/infra/ansible/roles/adguard/templates/nftables.conf.j2
+++ b/infra/ansible/roles/adguard/templates/nftables.conf.j2
@@ -1,0 +1,13 @@
+flush ruleset
+
+table inet filter {
+  chain input {
+    type filter hook input priority 0; policy accept;
+
+    iif "lo" accept
+    ct state established,related accept
+    ip saddr {{ edge_ip }} tcp dport {{ adguard_admin_port }} accept
+    ip saddr {{ homelab_tailscale_cidr }} tcp dport {{ adguard_admin_port }} accept
+    tcp dport {{ adguard_admin_port }} reject
+  }
+}

--- a/infra/ansible/roles/adguard_acme/tasks/main.yml
+++ b/infra/ansible/roles/adguard_acme/tasks/main.yml
@@ -45,7 +45,9 @@
       export ADGUARD_TLS_GROUP="{{ service_group }}"
       export ACME_EMAIL="holybaechu@proton.me"
       while true; do
-        /usr/local/bin/renew-adguard-cert
+        if ! /usr/local/bin/renew-adguard-cert; then
+          echo "AdGuard ACME renewal failed; retrying" >&2
+        fi
         sleep {{ adguard_acme_interval_seconds }}
       done
   no_log: true

--- a/infra/ansible/roles/caddy/tasks/main.yml
+++ b/infra/ansible/roles/caddy/tasks/main.yml
@@ -11,17 +11,30 @@
 - name: Install xcaddy
   ansible.builtin.command:
     cmd: "go install github.com/caddyserver/xcaddy/cmd/xcaddy@{{ xcaddy_version }}"
-    creates: /root/go/bin/xcaddy
+    creates: "/root/go/bin/xcaddy-{{ xcaddy_version }}.stamp"
+
+- name: Stamp xcaddy version
+  ansible.builtin.copy:
+    dest: "/root/go/bin/xcaddy-{{ xcaddy_version }}.stamp"
+    content: "{{ xcaddy_version }}\n"
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Set Caddy versioned build output path
+  ansible.builtin.set_fact:
+    caddy_build_output: >-
+      /tmp/caddy-{{ caddy_version }}-{{ caddy_cloudflare_module | regex_replace('[^A-Za-z0-9_.-]', '_') }}
 
 - name: Build Caddy with Cloudflare DNS module
   ansible.builtin.command:
-    cmd: "/root/go/bin/xcaddy build {{ caddy_version }} --with {{ caddy_cloudflare_module }}"
+    cmd: "/root/go/bin/xcaddy build {{ caddy_version }} --with {{ caddy_cloudflare_module }} --output {{ caddy_build_output }}"
     chdir: /tmp
-    creates: /tmp/caddy
+    creates: "{{ caddy_build_output }}"
 
 - name: Install Caddy binary
   ansible.builtin.copy:
-    src: /tmp/caddy
+    src: "{{ caddy_build_output }}"
     dest: /usr/local/bin/caddy
     remote_src: true
     mode: "0755"

--- a/infra/ansible/roles/ddns/tasks/main.yml
+++ b/infra/ansible/roles/ddns/tasks/main.yml
@@ -21,7 +21,9 @@
       export CLOUDFLARE_DDNS_TOKEN="{{ cloudflare_ddns_token }}"
       export DDNS_RECORD_NAMES="{{ ddns_record_names | join(' ') }}"
       while true; do
-        /usr/local/bin/update-cloudflare-ddns
+        if ! /usr/local/bin/update-cloudflare-ddns; then
+          echo "Cloudflare DDNS update failed; retrying" >&2
+        fi
         sleep {{ ddns_interval_seconds }}
       done
   no_log: true

--- a/infra/ansible/roles/downloads_vpn/templates/nftables.conf.j2
+++ b/infra/ansible/roles/downloads_vpn/templates/nftables.conf.j2
@@ -1,17 +1,30 @@
 flush ruleset
 
 table inet filter {
+  chain input {
+    type filter hook input priority 0; policy accept;
+
+    iif "lo" accept
+    ct state established,related accept
+    ip saddr {{ edge_ip }} tcp dport {{ qbittorrent_webui_port }} accept
+    ip saddr {{ homelab_tailscale_cidr }} tcp dport {{ qbittorrent_webui_port }} accept
+    tcp dport {{ qbittorrent_webui_port }} reject
+  }
+
   chain output {
     type filter hook output priority 0; policy accept;
 
     oif "lo" accept
+    udp dport 51820 accept
+
+    meta skuid {{ qbittorrent_uid }} oifname "{{ proton_wg_interface }}" accept
+    ct state established meta skuid {{ qbittorrent_uid }} ip daddr {{ edge_ip }} tcp sport {{ qbittorrent_webui_port }} accept
+    ct state established meta skuid {{ qbittorrent_uid }} ip daddr {{ homelab_tailscale_cidr }} tcp sport {{ qbittorrent_webui_port }} accept
+    meta skuid {{ qbittorrent_uid }} reject
+
     ip daddr {{ homelab_lan_cidr }} accept
     ip daddr {{ homelab_tailscale_cidr }} accept
     udp dport 53 accept
     tcp dport 53 accept
-    udp dport 51820 accept
-
-    meta skuid {{ qbittorrent_uid }} oifname "{{ proton_wg_interface }}" accept
-    meta skuid {{ qbittorrent_uid }} reject
   }
 }

--- a/infra/opentofu/modules/pve-lxc/main.tf
+++ b/infra/opentofu/modules/pve-lxc/main.tf
@@ -8,6 +8,8 @@ resource "proxmox_virtual_environment_container" "this" {
   tags          = var.tags
 
   lifecycle {
+    prevent_destroy = true
+
     ignore_changes = [
       features,
       device_passthrough,

--- a/scripts/ci/check_tofu_plan_safe.py
+++ b/scripts/ci/check_tofu_plan_safe.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Fail CI when an OpenTofu plan contains destructive actions."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _truthy(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _load_plan(argv: list[str]) -> dict[str, Any]:
+    if len(argv) > 2:
+        raise SystemExit("usage: check_tofu_plan_safe.py [PLAN_JSON]")
+
+    if len(argv) == 2:
+        with Path(argv[1]).open(encoding="utf-8") as handle:
+            return json.load(handle)
+
+    return json.load(sys.stdin)
+
+
+def _destructive_changes(plan: dict[str, Any]) -> list[str]:
+    destructive = []
+    for resource in plan.get("resource_changes", []):
+        actions = resource.get("change", {}).get("actions", [])
+        if "delete" in actions:
+            address = resource.get("address", "<unknown>")
+            destructive.append(f"{address}: {','.join(actions)}")
+    return destructive
+
+
+def main(argv: list[str]) -> int:
+    plan = _load_plan(argv)
+    destructive = _destructive_changes(plan)
+
+    if not destructive:
+        print("OpenTofu plan safety check passed: no destructive actions.")
+        return 0
+
+    print("OpenTofu plan contains destructive actions:", file=sys.stderr)
+    for change in destructive:
+        print(f"- {change}", file=sys.stderr)
+
+    if _truthy(os.environ.get("ALLOW_TOFU_DESTROY")):
+        print("ALLOW_TOFU_DESTROY is set; allowing destructive plan.", file=sys.stderr)
+        return 0
+
+    print(
+        "Refusing to continue. Set ALLOW_TOFU_DESTROY=true only for an intentional "
+        "manual destroy workflow.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/ci/tofu-apply.sh
+++ b/scripts/ci/tofu-apply.sh
@@ -4,4 +4,4 @@ set -eu
 cd infra/opentofu/envs/prod
 test -f prod.tfplan
 test -f ci.auto.tfvars.json
-tofu apply -auto-approve prod.tfplan
+tofu apply -input=false -auto-approve prod.tfplan

--- a/scripts/ci/tofu-plan.sh
+++ b/scripts/ci/tofu-plan.sh
@@ -30,8 +30,9 @@ if [ -n "${TOFU_STATE_ENDPOINT:-}" ]; then
     -backend-config="use_path_style=true"
 fi
 
-tofu init "$@"
+tofu init -input=false "$@"
 tofu fmt -recursive -check ../..
 tofu validate
 
-tofu plan -out=prod.tfplan
+tofu plan -input=false -out=prod.tfplan
+tofu show -json prod.tfplan | python3 ../../../../scripts/ci/check_tofu_plan_safe.py

--- a/tests/dns/test_adguard_acme_script.py
+++ b/tests/dns/test_adguard_acme_script.py
@@ -12,3 +12,29 @@ def test_adguard_acme_script_is_noninteractive():
     assert "--accept-tos" in script
     assert "run || lego" not in script
 
+
+def test_adguard_acme_restart_failure_is_not_hidden_when_service_exists():
+    script = (
+        REPO_ROOT / "apps" / "dns" / "acme" / "renew-adguard-cert.sh"
+    ).read_text(encoding="utf-8")
+
+    assert "rc-service adguardhome restart || true" not in script
+    assert "if [ -x /etc/init.d/adguardhome ]; then" in script
+    assert "rc-service adguardhome restart" in script
+    assert "rc-service adguardhome status" in script
+
+
+def test_adguard_acme_loop_survives_transient_renewal_failures():
+    tasks = (
+        REPO_ROOT
+        / "infra"
+        / "ansible"
+        / "roles"
+        / "adguard_acme"
+        / "tasks"
+        / "main.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "if ! /usr/local/bin/renew-adguard-cert; then" in tasks
+    assert "AdGuard ACME renewal failed; retrying" in tasks
+    assert "sleep {{ adguard_acme_interval_seconds }}" in tasks

--- a/tests/dns/test_adguard_role.py
+++ b/tests/dns/test_adguard_role.py
@@ -64,9 +64,39 @@ def test_adguard_role_hashes_plaintext_admin_password():
     ).read_text(encoding="utf-8")
 
     assert "adguard_admin_password is defined" in tasks
-    assert "Hash AdGuard admin password" in tasks
-    assert "htpasswd" in tasks
+    assert "Read existing AdGuard admin password hash" in tasks
+    assert "Verify existing AdGuard admin password hash" in tasks
+    assert "Hash AdGuard admin password when rotation is required" in tasks
+    assert "adguard_existing_admin_hash_verify.rc | default(1) != 0" in tasks
     assert "adguard_admin_password_hash" in tasks
+
+
+def test_adguard_role_limits_plain_http_admin_ui_with_nftables():
+    tasks = (
+        REPO_ROOT
+        / "infra"
+        / "ansible"
+        / "roles"
+        / "adguard"
+        / "tasks"
+        / "main.yml"
+    ).read_text(encoding="utf-8")
+    nftables = (
+        REPO_ROOT
+        / "infra"
+        / "ansible"
+        / "roles"
+        / "adguard"
+        / "templates"
+        / "nftables.conf.j2"
+    ).read_text(encoding="utf-8")
+
+    assert "- nftables" in tasks
+    assert "Install AdGuard nftables config" in tasks
+    assert "Enable AdGuard nftables" in tasks
+    assert "ip saddr {{ edge_ip }} tcp dport {{ adguard_admin_port }} accept" in nftables
+    assert "ip saddr {{ homelab_tailscale_cidr }} tcp dport {{ adguard_admin_port }} accept" in nftables
+    assert "tcp dport {{ adguard_admin_port }} reject" in nftables
 
 
 def test_adguard_role_uses_configured_admin_username():

--- a/tests/downloads/test_downloads_vpn_role.py
+++ b/tests/downloads/test_downloads_vpn_role.py
@@ -17,3 +17,76 @@ def test_downloads_vpn_installs_resolvconf_provider_for_wg_quick_dns():
 
     assert "- openresolv" in tasks
 
+
+def test_qbittorrent_uid_is_rejected_before_general_dns_allow():
+    nftables = (
+        REPO_ROOT
+        / "infra"
+        / "ansible"
+        / "roles"
+        / "downloads_vpn"
+        / "templates"
+        / "nftables.conf.j2"
+    ).read_text(encoding="utf-8")
+
+    reject_rule = nftables.index("meta skuid {{ qbittorrent_uid }} reject")
+    dns_allow = nftables.index("udp dport 53 accept")
+    lan_allow = nftables.index("ip daddr {{ homelab_lan_cidr }} accept")
+
+    assert reject_rule < dns_allow
+    assert reject_rule < lan_allow
+
+
+def test_qbittorrent_webui_responses_are_allowed_before_uid_reject():
+    nftables = (
+        REPO_ROOT
+        / "infra"
+        / "ansible"
+        / "roles"
+        / "downloads_vpn"
+        / "templates"
+        / "nftables.conf.j2"
+    ).read_text(encoding="utf-8")
+
+    edge_response = "ct state established meta skuid {{ qbittorrent_uid }} ip daddr {{ edge_ip }} tcp sport {{ qbittorrent_webui_port }} accept"
+    tailnet_response = "ct state established meta skuid {{ qbittorrent_uid }} ip daddr {{ homelab_tailscale_cidr }} tcp sport {{ qbittorrent_webui_port }} accept"
+    reject_rule = nftables.index("meta skuid {{ qbittorrent_uid }} reject")
+
+    assert edge_response in nftables
+    assert tailnet_response in nftables
+    assert nftables.index(edge_response) < reject_rule
+    assert nftables.index(tailnet_response) < reject_rule
+
+
+def test_qbittorrent_webui_input_is_limited_to_edge_and_tailscale():
+    nftables = (
+        REPO_ROOT
+        / "infra"
+        / "ansible"
+        / "roles"
+        / "downloads_vpn"
+        / "templates"
+        / "nftables.conf.j2"
+    ).read_text(encoding="utf-8")
+
+    assert "chain input" in nftables
+    assert "ip saddr {{ edge_ip }} tcp dport {{ qbittorrent_webui_port }} accept" in nftables
+    assert "ip saddr {{ homelab_tailscale_cidr }} tcp dport {{ qbittorrent_webui_port }} accept" in nftables
+    assert "tcp dport {{ qbittorrent_webui_port }} reject" in nftables
+
+
+def test_proton_server_list_is_pinned_to_an_immutable_commit():
+    downloads_vars = (
+        REPO_ROOT
+        / "infra"
+        / "ansible"
+        / "inventory"
+        / "prod"
+        / "group_vars"
+        / "downloads.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "refs/heads/main" not in downloads_vars
+    assert "raw.githubusercontent.com/qdm12/gluetun-servers/" in downloads_vars
+    assert "14277e92ce8291eb4515cd9af0dfad383a23f145" in downloads_vars
+

--- a/tests/edge/test_caddy_openrc_template.py
+++ b/tests/edge/test_caddy_openrc_template.py
@@ -20,3 +20,30 @@ def test_caddy_openrc_exports_environment_from_confd():
     assert "export XDG_CONFIG_HOME" in template
     assert "export HOME" in template
 
+
+def test_caddy_build_is_reproducible_and_version_sensitive():
+    tasks = (
+        REPO_ROOT
+        / "infra"
+        / "ansible"
+        / "roles"
+        / "caddy"
+        / "tasks"
+        / "main.yml"
+    ).read_text(encoding="utf-8")
+    edge_vars = (
+        REPO_ROOT
+        / "infra"
+        / "ansible"
+        / "inventory"
+        / "prod"
+        / "group_vars"
+        / "edge.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "github.com/caddy-dns/cloudflare@v" in edge_vars
+    assert "caddy_build_output" in tasks
+    assert "--output {{ caddy_build_output }}" in tasks
+    assert "creates: \"{{ caddy_build_output }}\"" in tasks
+    assert "xcaddy-{{ xcaddy_version }}.stamp" in tasks
+    assert "creates: /tmp/caddy" not in tasks

--- a/tests/edge/test_ddns_script.py
+++ b/tests/edge/test_ddns_script.py
@@ -13,3 +13,19 @@ def test_ddns_script_exists_and_targets_cloudflare_api():
     assert "DDNS_RECORD_NAMES" in content
     assert "api.cloudflare.com/client/v4/zones" in content
     assert "api.ipify.org" in content
+
+
+def test_ddns_loop_survives_transient_update_failures():
+    tasks = (
+        REPO_ROOT
+        / "infra"
+        / "ansible"
+        / "roles"
+        / "ddns"
+        / "tasks"
+        / "main.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "if ! /usr/local/bin/update-cloudflare-ddns; then" in tasks
+    assert "Cloudflare DDNS update failed; retrying" in tasks
+    assert "sleep {{ ddns_interval_seconds }}" in tasks

--- a/tests/repo/test_github_workflows.py
+++ b/tests/repo/test_github_workflows.py
@@ -106,9 +106,35 @@ def test_cd_tofu_plan_and_apply_use_generated_variable_file():
     assert "-var=" not in plan_script
     assert "write_tofu_vars.py" in plan_script
     assert "terraform.tfvars.example" not in plan_script
-    assert "tofu plan -out=prod.tfplan" in plan_script
+    assert "tofu plan -input=false -out=prod.tfplan" in plan_script
     assert "test -f ci.auto.tfvars.json" in apply_script
-    assert "tofu apply -auto-approve prod.tfplan" in apply_script
+    assert "tofu apply -input=false -auto-approve prod.tfplan" in apply_script
+
+
+def test_cd_workflow_only_deploys_prod_from_main():
+    workflow = (REPO_ROOT / ".github" / "workflows" / "cd.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "jobs:\n  deploy:\n    if: github.ref == 'refs/heads/main'" in workflow
+
+
+def test_tofu_apply_is_guarded_against_destroying_lxcs():
+    module = (
+        REPO_ROOT / "infra" / "opentofu" / "modules" / "pve-lxc" / "main.tf"
+    ).read_text(encoding="utf-8")
+    plan_script = (REPO_ROOT / "scripts" / "ci" / "tofu-plan.sh").read_text(
+        encoding="utf-8"
+    )
+    guard_script = (REPO_ROOT / "scripts" / "ci" / "check_tofu_plan_safe.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert "prevent_destroy = true" in module
+    assert "tofu show -json prod.tfplan" in plan_script
+    assert "check_tofu_plan_safe.py" in plan_script
+    assert "ALLOW_TOFU_DESTROY" in guard_script
+    assert '"delete" in actions' in guard_script
 
 
 def test_cd_workflow_does_not_plan_one_time_hermes_lxc_replacement():

--- a/tests/repo/test_tofu_plan_guard.py
+++ b/tests/repo/test_tofu_plan_guard.py
@@ -1,0 +1,76 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GUARD = REPO_ROOT / "scripts" / "ci" / "check_tofu_plan_safe.py"
+
+
+def run_guard(plan, *, allow_destroy=False):
+    env = os.environ.copy()
+    if allow_destroy:
+        env["ALLOW_TOFU_DESTROY"] = "true"
+    else:
+        env.pop("ALLOW_TOFU_DESTROY", None)
+
+    return subprocess.run(
+        [sys.executable, str(GUARD)],
+        input=json.dumps(plan),
+        text=True,
+        capture_output=True,
+        check=False,
+        env=env,
+    )
+
+
+def test_tofu_plan_guard_accepts_non_destructive_changes():
+    result = run_guard(
+        {
+            "resource_changes": [
+                {
+                    "address": "module.lxc[\"dns\"]",
+                    "change": {"actions": ["update"]},
+                }
+            ]
+        }
+    )
+
+    assert result.returncode == 0
+    assert "no destructive actions" in result.stdout
+
+
+def test_tofu_plan_guard_rejects_delete_actions_by_default():
+    result = run_guard(
+        {
+            "resource_changes": [
+                {
+                    "address": "module.lxc[\"dns\"]",
+                    "change": {"actions": ["delete", "create"]},
+                }
+            ]
+        }
+    )
+
+    assert result.returncode == 1
+    assert "module.lxc" in result.stderr
+    assert "ALLOW_TOFU_DESTROY" in result.stderr
+
+
+def test_tofu_plan_guard_can_be_overridden_for_manual_destroy_workflows():
+    result = run_guard(
+        {
+            "resource_changes": [
+                {
+                    "address": "module.lxc[\"dns\"]",
+                    "change": {"actions": ["delete"]},
+                }
+            ]
+        },
+        allow_destroy=True,
+    )
+
+    assert result.returncode == 0
+    assert "allowing destructive plan" in result.stderr


### PR DESCRIPTION
## Summary
- Guard OpenTofu production plans against destructive actions and restrict prod CD to `main`.
- Harden qBittorrent/AdGuard access with nftables and fix qBittorrent DNS leak while preserving Web UI responses.
- Make DDNS/ACME loops resilient, stop hiding AdGuard restart failures, pin Proton server list/Caddy module, and avoid unnecessary AdGuard password hash churn.
- Add regression tests for the new guardrails.

## Test Plan
- [x] `pytest -q`
- [x] `python -m compileall -q apps scripts tests`
- [x] `sh -n apps/edge/ddns/update-cloudflare-ddns.sh apps/dns/acme/renew-adguard-cert.sh scripts/ci/*.sh`
- [x] `git diff --cached --check`
- [x] `tofu init -backend=false -input=false && tofu fmt -recursive -check ../.. && tofu validate`
- [x] `ansible-playbook --syntax-check` for `bootstrap.yml`, `site.yml`, `validate.yml`

## Notes
- Ansible syntax-check still emits the existing host/group same-name warnings.
- `nft` is not installed in the local Hermes environment, so nftables semantic validation was limited to tests and Ansible syntax-check.
