### PR TITLE
fix: retry LXC SSH host key scanning

### DIFF
--- a/infra/ansible/playbooks/bootstrap.yml
+++ b/infra/ansible/playbooks/bootstrap.yml
@@ -25,12 +25,24 @@
     - name: Add LXC SSH host keys to known_hosts
       ansible.builtin.shell: |
         set -eu
+        host="{{ item }}"
         mkdir -p "${HOME}/.ssh"
         touch "${HOME}/.ssh/known_hosts"
         chmod 700 "${HOME}/.ssh"
         chmod 600 "${HOME}/.ssh/known_hosts"
-        ssh-keygen -R "{{ item }}" >/dev/null 2>&1 || true
-        ssh-keyscan -H -T 10 "{{ item }}" >> "${HOME}/.ssh/known_hosts"
+        ssh-keygen -R "${host}" >/dev/null 2>&1 || true
+
+        for attempt in 1 2 3 4 5 6; do
+          if ssh-keyscan -H -T 10 "${host}" >> "${HOME}/.ssh/known_hosts"; then
+            exit 0
+          fi
+
+          echo "ssh-keyscan failed for ${host} (attempt ${attempt}/6); retrying" >&2
+          sleep 5
+        done
+
+        echo "ssh-keyscan failed for ${host} after 6 attempts" >&2
+        exit 1
       args:
         executable: /bin/sh
       changed_when: true

--- a/tests/infra/test_bootstrap_playbook.py
+++ b/tests/infra/test_bootstrap_playbook.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_bootstrap_retries_ssh_keyscan_for_lxc_hosts():
+    bootstrap = (
+        REPO_ROOT / "infra" / "ansible" / "playbooks" / "bootstrap.yml"
+    ).read_text(encoding="utf-8")
+
+    assert 'host="{{ item }}"' in bootstrap
+    assert "for attempt in 1 2 3 4 5 6; do" in bootstrap
+    assert 'ssh-keyscan -H -T 10 "${host}"' in bootstrap
+    assert "ssh-keyscan failed for ${host} after 6 attempts" in bootstrap


### PR DESCRIPTION
## Summary
- Retry LXC ssh-keyscan during bootstrap before failing
- Keep removing stale known_hosts entries before scanning
- Add regression coverage for bootstrap keyscan retry logic

## Why
The main CD run failed because the DNS LXC (192.168.0.3) did not respond to a single 10-second ssh-keyscan during bootstrap:
https://github.com/holybaechu/homelab/actions/runs/27949243531/job/82701692804

## Test Plan
- PYTHONPATH=$PWD pytest tests/infra/test_bootstrap_playbook.py
- PYTHONPATH=$PWD pytest
- git diff --check
- ANSIBLE_CONFIG=infra/ansible/ansible.cfg ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/bootstrap.yml --syntax-check
- ANSIBLE_CONFIG=infra/ansible/ansible.cfg ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/site.yml --syntax-check
- ANSIBLE_CONFIG=infra/ansible/ansible.cfg ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/validate.yml --syntax-check