### PR TITLE
fix: allow qBittorrent writes to public share

### DIFF
--- a/infra/ansible/inventory/prod/group_vars/all.yml
+++ b/infra/ansible/inventory/prod/group_vars/all.yml
@@ -57,9 +57,9 @@ pve_lxc_root_options:
       - description: mount downloads data
         pattern: '^mp0: /var/lib/homelab/downloads,mp=/downloads(,.*)?$'
         pct_args: '-mp0 /var/lib/homelab/downloads,mp=/downloads'
-      - description: mount public Copyparty share read-only for migrated qBittorrent sessions
-        pattern: '^mp1: /var/lib/homelab/copyparty/public,mp=/public(,.*)?$'
-        pct_args: '-mp1 /var/lib/homelab/copyparty/public,mp=/public,ro=1'
+      - description: mount public Copyparty share read-write for seeded public content
+        pattern: '^mp1: /var/lib/homelab/copyparty/public,mp=/public$'
+        pct_args: '-mp1 /var/lib/homelab/copyparty/public,mp=/public'
   - vmid: 114
     name: files
     bind_mount_sources:

--- a/infra/ansible/inventory/prod/group_vars/svc_downloads.yml
+++ b/infra/ansible/inventory/prod/group_vars/svc_downloads.yml
@@ -1,6 +1,7 @@
 downloads_mount_path: /downloads
 downloads_complete_path: /downloads/complete
 downloads_incomplete_path: /downloads/incomplete
+copyparty_public_mount_path: /public
 proton_wg_interface: wg-proton
 proton_server_list_url: https://raw.githubusercontent.com/qdm12/gluetun-servers/14277e92ce8291eb4515cd9af0dfad383a23f145/pkg/servers/protonvpn.json
 proton_server_country: Japan

--- a/infra/ansible/roles/pve_homelab_storage/tasks/main.yml
+++ b/infra/ansible/roles/pve_homelab_storage/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Install ACL tools for shared bind-mount permissions
+  ansible.builtin.apt:
+    name: acl
+    state: present
+
 - name: Configure homelab data filesystem
   ansible.builtin.shell: |
     set -eu
@@ -7,6 +12,7 @@
     mount_path="{{ homelab_data_mount }}"
     tmp_mount="/mnt/{{ homelab_data_lv_name }}-init"
     permissions_marker="${mount_path}/.homelab-permissions-initialized"
+    public_qbt_acl_marker="${mount_path}/.homelab-public-qbittorrent-acl-v1"
 
     if [ ! -e "${lv_path}" ]; then
       lvcreate -V "{{ homelab_data_lv_size }}" -T pve/data -n "{{ homelab_data_lv_name }}"
@@ -63,6 +69,16 @@
       changed=1
     else
       echo "permissions_changed=0"
+    fi
+
+    if [ ! -e "${public_qbt_acl_marker}" ] || [ "{{ homelab_data_reconcile_permissions | default(false) | lower }}" = "true" ]; then
+      setfacl -R -m "u:{{ homelab_container_uid_offset + service_uid }}:rwX,u:{{ homelab_container_uid_offset + downloads_service_uid }}:rwX" "${mount_path}/copyparty/public"
+      find "${mount_path}/copyparty/public" -type d -exec setfacl -m "d:u:{{ homelab_container_uid_offset + service_uid }}:rwx,d:u:{{ homelab_container_uid_offset + downloads_service_uid }}:rwx" {} +
+      touch "${public_qbt_acl_marker}"
+      echo "public_qbittorrent_acl_changed=1"
+      changed=1
+    else
+      echo "public_qbittorrent_acl_changed=0"
     fi
 
     if [ "${changed}" -eq 1 ]; then

--- a/infra/ansible/roles/qbittorrent/templates/qbittorrent.service.j2
+++ b/infra/ansible/roles/qbittorrent/templates/qbittorrent.service.j2
@@ -17,7 +17,7 @@ ProtectHome=true
 ProtectSystem=full
 RestrictSUIDSGID=true
 LockPersonality=true
-ReadWritePaths=/var/lib/qbittorrent {{ downloads_mount_path }}
+ReadWritePaths=/var/lib/qbittorrent {{ downloads_mount_path }} {{ copyparty_public_mount_path }}
 
 [Install]
 WantedBy=multi-user.target

--- a/tests/infra/test_service_hardening_review.py
+++ b/tests/infra/test_service_hardening_review.py
@@ -60,6 +60,21 @@ def test_qbittorrent_and_hermes_units_use_systemd_sandboxing():
         assert "ReadWritePaths=" in unit
 
 
+def test_qbittorrent_can_write_public_copyparty_share_for_seeding():
+    all_vars = (REPO_ROOT / "infra" / "ansible" / "inventory" / "prod" / "group_vars" / "all.yml").read_text(encoding="utf-8")
+    downloads_vars = (REPO_ROOT / "infra" / "ansible" / "inventory" / "prod" / "group_vars" / "svc_downloads.yml").read_text(encoding="utf-8")
+    qbt_unit = (REPO_ROOT / "infra" / "ansible" / "roles" / "qbittorrent" / "templates" / "qbittorrent.service.j2").read_text(encoding="utf-8")
+    storage_tasks = (REPO_ROOT / "infra" / "ansible" / "roles" / "pve_homelab_storage" / "tasks" / "main.yml").read_text(encoding="utf-8")
+
+    assert "mp=/public,ro=1" not in all_vars
+    assert "mp=/public" in all_vars
+    assert "copyparty_public_mount_path: /public" in downloads_vars
+    assert "{{ copyparty_public_mount_path }}" in qbt_unit
+    assert "setfacl -R -m" in storage_tasks
+    assert "homelab_container_uid_offset + downloads_service_uid" in storage_tasks
+    assert '"${mount_path}/copyparty/public"' in storage_tasks
+
+
 def test_tailscale_up_is_not_reported_changed_unconditionally():
     tasks = (REPO_ROOT / "infra" / "ansible" / "roles" / "tailscale_gateway" / "tasks" / "main.yml").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- mount the Copyparty public share read-write in the downloads LXC so qBittorrent can seed from /public
- add /public to qBittorrent's systemd ReadWritePaths sandbox
- apply host ACLs so both Copyparty and qBittorrent mapped UIDs can write the public share

## Test Plan
- PYTHONPATH=$PWD .venv/bin/pytest -q
- .venv/bin/python -m compileall -q scripts tests
- ANSIBLE_CONFIG=infra/ansible/ansible.cfg .venv/bin/ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/site.yml --syntax-check
- ANSIBLE_CONFIG=infra/ansible/ansible.cfg .venv/bin/ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/bootstrap.yml --syntax-check
- .venv/bin/python scripts/ci/render_ansible_inventory.py --check