### PR TITLE
fix: route only qBittorrent through downloads VPN

### DIFF
--- a/infra/ansible/inventory/prod/group_vars/svc_downloads.yml
+++ b/infra/ansible/inventory/prod/group_vars/svc_downloads.yml
@@ -11,6 +11,8 @@ proton_wireguard_endpoint_port: 51820
 proton_wireguard_dns: 1.1.1.1
 proton_wireguard_allowed_ips: "0.0.0.0/0, ::/0"
 proton_natpmp_gateway: 10.2.0.1
+proton_wireguard_table: 51820
+proton_wireguard_rule_priority: 100
 qbittorrent_webui_port: 8080
 qbittorrent_webui_username: holybaechu
 # renovate: datasource=github-releases depName=VueTorrent/VueTorrent versioning=semver extractVersion=^v(?<version>.*)$

--- a/infra/ansible/playbooks/site.yml
+++ b/infra/ansible/playbooks/site.yml
@@ -35,8 +35,8 @@
   hosts: svc_downloads
   gather_facts: true
   roles:
-    - downloads_vpn
     - qbittorrent
+    - downloads_vpn
 
 - name: Configure files LXC
   hosts: svc_files

--- a/infra/ansible/roles/downloads_vpn/tasks/main.yml
+++ b/infra/ansible/roles/downloads_vpn/tasks/main.yml
@@ -65,3 +65,23 @@
     name: "wg-quick@{{ proton_wg_interface }}"
     enabled: true
     state: started
+
+- name: Apply VPN configuration changes before starting qBittorrent
+  ansible.builtin.meta: flush_handlers
+
+- name: Check qBittorrent service units
+  ansible.builtin.stat:
+    path: "/etc/systemd/system/{{ item }}"
+  loop:
+    - qbittorrent.service
+    - proton-natpmp-qbt.timer
+  register: downloads_vpn_qbittorrent_units
+
+- name: Start qBittorrent and NAT-PMP timer after VPN is up
+  ansible.builtin.systemd:
+    name: "{{ item.item }}"
+    daemon_reload: true
+    enabled: true
+    state: started
+  loop: "{{ downloads_vpn_qbittorrent_units.results }}"
+  when: item.stat.exists

--- a/infra/ansible/roles/downloads_vpn/templates/wg-proton.conf.j2
+++ b/infra/ansible/roles/downloads_vpn/templates/wg-proton.conf.j2
@@ -2,6 +2,20 @@
 PrivateKey = {{ proton_wireguard_private_key }}
 Address = {{ proton_wireguard_address }}
 DNS = {{ proton_wireguard_dns }}
+Table = off
+PostUp = ip -4 route replace default dev %i table {{ proton_wireguard_table }}
+PostUp = ip -4 route replace {{ proton_natpmp_gateway }}/32 dev %i
+PostUp = ip -4 rule del priority {{ (proton_wireguard_rule_priority | int) - 2 }} uidrange {{ qbittorrent_uid }}-{{ qbittorrent_uid }} to {{ homelab_lan_cidr }} lookup main 2>/dev/null || true
+PostUp = ip -4 rule add priority {{ (proton_wireguard_rule_priority | int) - 2 }} uidrange {{ qbittorrent_uid }}-{{ qbittorrent_uid }} to {{ homelab_lan_cidr }} lookup main
+PostUp = ip -4 rule del priority {{ (proton_wireguard_rule_priority | int) - 1 }} uidrange {{ qbittorrent_uid }}-{{ qbittorrent_uid }} to {{ homelab_tailscale_cidr }} lookup main 2>/dev/null || true
+PostUp = ip -4 rule add priority {{ (proton_wireguard_rule_priority | int) - 1 }} uidrange {{ qbittorrent_uid }}-{{ qbittorrent_uid }} to {{ homelab_tailscale_cidr }} lookup main
+PostUp = ip -4 rule del priority {{ proton_wireguard_rule_priority }} uidrange {{ qbittorrent_uid }}-{{ qbittorrent_uid }} lookup {{ proton_wireguard_table }} 2>/dev/null || true
+PostUp = ip -4 rule add priority {{ proton_wireguard_rule_priority }} uidrange {{ qbittorrent_uid }}-{{ qbittorrent_uid }} lookup {{ proton_wireguard_table }}
+PreDown = ip -4 rule del priority {{ proton_wireguard_rule_priority }} uidrange {{ qbittorrent_uid }}-{{ qbittorrent_uid }} lookup {{ proton_wireguard_table }} 2>/dev/null || true
+PreDown = ip -4 rule del priority {{ (proton_wireguard_rule_priority | int) - 1 }} uidrange {{ qbittorrent_uid }}-{{ qbittorrent_uid }} to {{ homelab_tailscale_cidr }} lookup main 2>/dev/null || true
+PreDown = ip -4 rule del priority {{ (proton_wireguard_rule_priority | int) - 2 }} uidrange {{ qbittorrent_uid }}-{{ qbittorrent_uid }} to {{ homelab_lan_cidr }} lookup main 2>/dev/null || true
+PreDown = ip -4 route del default dev %i table {{ proton_wireguard_table }} 2>/dev/null || true
+PreDown = ip -4 route del {{ proton_natpmp_gateway }}/32 dev %i 2>/dev/null || true
 
 [Peer]
 PublicKey = {{ proton_wireguard_selected.public_key }}

--- a/infra/ansible/roles/qbittorrent/tasks/main.yml
+++ b/infra/ansible/roles/qbittorrent/tasks/main.yml
@@ -224,7 +224,6 @@
     name: "{{ item }}"
     daemon_reload: true
     enabled: true
-    state: started
   loop:
     - qbittorrent.service
     - proton-natpmp-qbt.timer

--- a/tests/infra/test_service_hardening_review.py
+++ b/tests/infra/test_service_hardening_review.py
@@ -75,6 +75,43 @@ def test_qbittorrent_can_write_public_copyparty_share_for_seeding():
     assert '"${mount_path}/copyparty/public"' in storage_tasks
 
 
+def test_downloads_routes_only_qbittorrent_through_vpn():
+    site = (REPO_ROOT / "infra" / "ansible" / "playbooks" / "site.yml").read_text(encoding="utf-8")
+    downloads_vars = (REPO_ROOT / "infra" / "ansible" / "inventory" / "prod" / "group_vars" / "svc_downloads.yml").read_text(encoding="utf-8")
+    common_debian = (REPO_ROOT / "infra" / "ansible" / "roles" / "common_debian" / "tasks" / "main.yml").read_text(encoding="utf-8")
+    qbt_tasks = (REPO_ROOT / "infra" / "ansible" / "roles" / "qbittorrent" / "tasks" / "main.yml").read_text(encoding="utf-8")
+    qbt_config = (REPO_ROOT / "infra" / "ansible" / "roles" / "qbittorrent" / "templates" / "qBittorrent.conf.j2").read_text(encoding="utf-8")
+    nftables = (REPO_ROOT / "infra" / "ansible" / "roles" / "downloads_vpn" / "templates" / "nftables.conf.j2").read_text(encoding="utf-8")
+    wg_config = (REPO_ROOT / "infra" / "ansible" / "roles" / "downloads_vpn" / "templates" / "wg-proton.conf.j2").read_text(encoding="utf-8")
+    vpn_tasks = (REPO_ROOT / "infra" / "ansible" / "roles" / "downloads_vpn" / "tasks" / "main.yml").read_text(encoding="utf-8")
+
+    downloads_play = site.split("- name: Configure downloads LXC", maxsplit=1)[1].split("- name: Configure files LXC", maxsplit=1)[0]
+    assert downloads_play.index("- qbittorrent") < downloads_play.index("- downloads_vpn")
+
+    assert "apt_bypass_vpn" not in downloads_vars
+    assert "apt_bypass_vpn" not in common_debian
+    assert "proton_wireguard_table: 51820" in downloads_vars
+    assert "proton_wireguard_rule_priority: 100" in downloads_vars
+    assert "Table = off" in wg_config
+    assert "to {{ homelab_lan_cidr }} lookup main" in wg_config
+    assert "to {{ homelab_tailscale_cidr }} lookup main" in wg_config
+    assert "ip -4 route replace default dev %i table {{ proton_wireguard_table }}" in wg_config
+    assert "uidrange {{ qbittorrent_uid }}-{{ qbittorrent_uid }} lookup {{ proton_wireguard_table }}" in wg_config
+    assert "{{ proton_natpmp_gateway }}/32 dev %i" in wg_config
+    assert "ip -4 rule del priority {{ proton_wireguard_rule_priority }}" in wg_config
+
+    assert "Connection\\Interface={{ proton_wg_interface }}" in qbt_config
+    assert "meta skuid {{ qbittorrent_uid }} oifname \"{{ proton_wg_interface }}\" accept" in nftables
+    assert "meta skuid {{ qbittorrent_uid }} reject" in nftables
+    assert "meta skuid != {{ qbittorrent_uid }} accept" in nftables
+
+    enable_qbt_task = qbt_tasks.split("- name: Enable qBittorrent and NAT-PMP timer", maxsplit=1)[1]
+    assert "enabled: true" in enable_qbt_task
+    assert "state: started" not in enable_qbt_task
+
+    assert vpn_tasks.index("Enable WireGuard") < vpn_tasks.index("Start qBittorrent and NAT-PMP timer after VPN is up")
+
+
 def test_tailscale_up_is_not_reported_changed_unconditionally():
     tasks = (REPO_ROOT / "infra" / "ansible" / "roles" / "tailscale_gateway" / "tasks" / "main.yml").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- disable WireGuard's automatic default-route takeover in the downloads LXC with `Table = off`
- add explicit policy routing so only the qBittorrent UID uses the Proton WireGuard routing table
- preserve LAN/Tailscale main-table exceptions for qBittorrent WebUI responses and keep NAT-PMP gateway routing over the tunnel
- keep qBittorrent configured before the downloads VPN role, but start qBittorrent/NAT-PMP only after WireGuard is up

## Test Plan
- PYTHONPATH=$PWD .venv/bin/pytest -q
- rendered `wg-proton.conf.j2` with dummy values to verify Jinja expressions
- .venv/bin/python -m compileall -q scripts tests
- ANSIBLE_CONFIG=infra/ansible/ansible.cfg .venv/bin/ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/site.yml --syntax-check
- ANSIBLE_CONFIG=infra/ansible/ansible.cfg .venv/bin/ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/bootstrap.yml --syntax-check
- .venv/bin/python scripts/ci/render_ansible_inventory.py --check
