### PR TITLE
fix: migrate downloads VPN routing before apt

### DIFF
--- a/infra/ansible/roles/common_debian/tasks/main.yml
+++ b/infra/ansible/roles/common_debian/tasks/main.yml
@@ -1,4 +1,50 @@
 ---
+- name: Migrate active downloads WireGuard away from host-wide VPN before package installs
+  ansible.builtin.shell: |
+    set -eu
+    interface={{ proton_wg_interface | quote }}
+    table={{ proton_wireguard_table | quote }}
+    priority={{ proton_wireguard_rule_priority | quote }}
+    qbt_uid={{ qbittorrent_uid | quote }}
+    changed=0
+
+    if ! command -v wg >/dev/null 2>&1 || ! ip link show "${interface}" >/dev/null 2>&1; then
+      echo "changed=no"
+      exit 0
+    fi
+
+    fwmark="$(wg show "${interface}" fwmark 2>/dev/null || true)"
+    if [ -n "${fwmark}" ] && [ "${fwmark}" != "off" ]; then
+      for pref in $(ip -4 rule show | awk -v fwmark="${fwmark}" '$0 ~ "not from all fwmark " fwmark && $0 ~ "lookup" { sub(":", "", $1); print $1 }'); do
+        if ip -4 rule del priority "${pref}"; then
+          changed=1
+        fi
+      done
+    fi
+
+    for pref in $(ip -4 rule show | awk '/lookup main suppress_prefixlength 0/ { sub(":", "", $1); print $1 }'); do
+      if ip -4 rule del priority "${pref}"; then
+        changed=1
+      fi
+    done
+
+    ip -4 route replace default dev "${interface}" table "${table}"
+    ip -4 route replace {{ proton_natpmp_gateway | quote }}/32 dev "${interface}"
+
+    ip -4 rule del priority "$((priority - 2))" uidrange "${qbt_uid}-${qbt_uid}" to {{ homelab_lan_cidr | quote }} lookup main 2>/dev/null || true
+    ip -4 rule add priority "$((priority - 2))" uidrange "${qbt_uid}-${qbt_uid}" to {{ homelab_lan_cidr | quote }} lookup main
+    ip -4 rule del priority "$((priority - 1))" uidrange "${qbt_uid}-${qbt_uid}" to {{ homelab_tailscale_cidr | quote }} lookup main 2>/dev/null || true
+    ip -4 rule add priority "$((priority - 1))" uidrange "${qbt_uid}-${qbt_uid}" to {{ homelab_tailscale_cidr | quote }} lookup main
+    ip -4 rule del priority "${priority}" uidrange "${qbt_uid}-${qbt_uid}" lookup "${table}" 2>/dev/null || true
+    ip -4 rule add priority "${priority}" uidrange "${qbt_uid}-${qbt_uid}" lookup "${table}"
+
+    echo "changed=yes"
+  args:
+    executable: /bin/sh
+  register: common_debian_downloads_vpn_route_migration
+  changed_when: "'changed=yes' in common_debian_downloads_vpn_route_migration.stdout"
+  when: proton_wireguard_table is defined
+
 - name: Install Debian base packages
   ansible.builtin.apt:
     name: "{{ common_debian_packages }}"

--- a/tests/infra/test_service_hardening_review.py
+++ b/tests/infra/test_service_hardening_review.py
@@ -90,6 +90,12 @@ def test_downloads_routes_only_qbittorrent_through_vpn():
 
     assert "apt_bypass_vpn" not in downloads_vars
     assert "apt_bypass_vpn" not in common_debian
+    assert "Migrate active downloads WireGuard away from host-wide VPN before package installs" in common_debian
+    assert common_debian.index("Migrate active downloads WireGuard away from host-wide VPN before package installs") < common_debian.index("Install Debian base packages")
+    assert "wg show \"${interface}\" fwmark" in common_debian
+    assert "not from all fwmark" in common_debian
+    assert "suppress_prefixlength 0" in common_debian
+    assert "uidrange \"${qbt_uid}-${qbt_uid}\" lookup \"${table}\"" in common_debian
     assert "proton_wireguard_table: 51820" in downloads_vars
     assert "proton_wireguard_rule_priority: 100" in downloads_vars
     assert "Table = off" in wg_config


### PR DESCRIPTION
## Summary
- add a pre-apt bootstrap migration for the downloads LXC when legacy WireGuard is already active
- remove wg-quick's old host-wide full-tunnel policy rules before Debian package installs
- re-apply qBittorrent-only UID routing so apt/system traffic can use the main route while qBittorrent stays on Proton VPN

## Test Plan
- PYTHONPATH=$PWD .venv/bin/pytest -q
- .venv/bin/python -m compileall -q scripts tests
- ANSIBLE_CONFIG=infra/ansible/ansible.cfg .venv/bin/ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/site.yml --syntax-check
- ANSIBLE_CONFIG=infra/ansible/ansible.cfg .venv/bin/ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/bootstrap.yml --syntax-check
- .venv/bin/python scripts/ci/render_ansible_inventory.py --check