### PR TITLE
fix: stop NAT-PMP before qBittorrent config updates

### DIFF
--- a/infra/ansible/roles/qbittorrent/tasks/main.yml
+++ b/infra/ansible/roles/qbittorrent/tasks/main.yml
@@ -143,10 +143,37 @@
 - name: Gather service facts before qBittorrent config update
   ansible.builtin.service_facts:
 
+- name: Stop NAT-PMP updater before applying changed qBittorrent config
+  ansible.builtin.shell: |
+    set -eu
+    changed=0
+
+    for unit in proton-natpmp-qbt.timer proton-natpmp-qbt.service; do
+      if systemctl cat "${unit}" >/dev/null 2>&1 && systemctl is-active --quiet "${unit}"; then
+        systemctl stop "${unit}"
+        changed=1
+      fi
+    done
+
+    if [ "${changed}" -eq 1 ]; then
+      echo "changed=yes"
+    else
+      echo "changed=no"
+    fi
+  args:
+    executable: /bin/sh
+  register: qbittorrent_stop_natpmp_before_config
+  changed_when: "'changed=yes' in qbittorrent_stop_natpmp_before_config.stdout"
+  when: qbittorrent_config_compare.rc != 0
+
 - name: Stop qBittorrent before applying changed config
   ansible.builtin.systemd:
     name: qbittorrent.service
     state: stopped
+  register: qbittorrent_stop_before_config
+  until: qbittorrent_stop_before_config is succeeded
+  retries: 3
+  delay: 3
   when:
     - qbittorrent_config_compare.rc != 0
     - "'qbittorrent.service' in ansible_facts.services"

--- a/tests/infra/test_service_hardening_review.py
+++ b/tests/infra/test_service_hardening_review.py
@@ -1,13 +1,25 @@
 from tests.helpers import REPO_ROOT
 
 
-def test_qbittorrent_config_update_only_stops_service_when_config_changes():
+def test_qbittorrent_config_update_stops_natpmp_before_qbittorrent_when_config_changes():
     tasks = (REPO_ROOT / "infra" / "ansible" / "roles" / "qbittorrent" / "tasks" / "main.yml").read_text(encoding="utf-8")
 
     assert "Render qBittorrent config candidate" in tasks
     assert "Compare qBittorrent config candidate" in tasks
     assert "when: qbittorrent_config_compare.rc != 0" in tasks
+    assert "Stop NAT-PMP updater before applying changed qBittorrent config" in tasks
     assert "Stop qBittorrent before applying changed config" in tasks
+    assert tasks.index("Stop NAT-PMP updater before applying changed qBittorrent config") < tasks.index("Stop qBittorrent before applying changed config")
+
+    natpmp_stop_task = tasks.split("- name: Stop NAT-PMP updater before applying changed qBittorrent config", maxsplit=1)[1].split("- name: Stop qBittorrent before applying changed config", maxsplit=1)[0]
+    assert "proton-natpmp-qbt.timer" in natpmp_stop_task
+    assert "proton-natpmp-qbt.service" in natpmp_stop_task
+    assert "qbittorrent_config_compare.rc != 0" in natpmp_stop_task
+
+    qbt_stop_task = tasks.split("- name: Stop qBittorrent before applying changed config", maxsplit=1)[1].split("- name: Install qBittorrent config", maxsplit=1)[0]
+    assert "retries:" in qbt_stop_task
+    assert "delay:" in qbt_stop_task
+    assert "until: qbittorrent_stop_before_config is succeeded" in qbt_stop_task
 
 
 def test_root_only_lxc_options_use_graceful_shutdown_before_stop():


### PR DESCRIPTION
## Summary
- stop the Proton NAT-PMP timer/service before stopping qBittorrent for config replacement
- retry the qBittorrent stop operation to avoid systemd stop/start job races
- add a regression test for the stop ordering and retry guard

## Diagnosis
The latest CD run got past the downloads apt task. It failed later at `qbittorrent : Stop qBittorrent before applying changed config` with `Job for qbittorrent.service canceled`.

The likely race is the 45-second NAT-PMP timer requiring qBittorrent while Ansible is trying to stop qBittorrent to replace its config.

## Test Plan
- PYTHONPATH=$PWD .venv/bin/pytest -q
- .venv/bin/python -m compileall -q scripts tests
- ANSIBLE_CONFIG=infra/ansible/ansible.cfg .venv/bin/ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/site.yml --syntax-check
- ANSIBLE_CONFIG=infra/ansible/ansible.cfg .venv/bin/ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/bootstrap.yml --syntax-check
- .venv/bin/python scripts/ci/render_ansible_inventory.py --check
