### PR TITLE
fix: remove public AdGuard DoH route

### DIFF
--- a/apps/dns/acme/renew-adguard-cert.sh
+++ b/apps/dns/acme/renew-adguard-cert.sh
@@ -3,7 +3,7 @@ set -eu
 
 export CF_DNS_API_TOKEN="${CLOUDFLARE_ADGUARD_ACME_TOKEN}"
 
-DOMAIN="${ADGUARD_CERT_DOMAIN:-dns.hchu.me}"
+DOMAIN="${ADGUARD_CERT_DOMAIN:-adguard.home.hchu.me}"
 CERT_DIR="${ADGUARD_TLS_DIR:-/opt/adguardhome/tls}"
 TLS_GROUP="${ADGUARD_TLS_GROUP:-homelab}"
 LEGO_PATH="${LEGO_PATH:-/var/lib/lego}"

--- a/apps/edge/Caddyfile
+++ b/apps/edge/Caddyfile
@@ -47,7 +47,11 @@ copyparty.hchu.me {
 adguard.home.hchu.me {
 	import private_only
 	import secure_headers
-	reverse_proxy 192.168.0.3:80
+	reverse_proxy https://192.168.0.3:443 {
+		transport http {
+			tls_server_name adguard.home.hchu.me
+		}
+	}
 }
 
 qbt.home.hchu.me {
@@ -71,16 +75,4 @@ router.home.hchu.me {
 	import private_only
 	import router_headers
 	reverse_proxy http://192.168.0.1
-}
-
-dns.hchu.me {
-	import secure_headers
-	handle /dns-query {
-		reverse_proxy https://192.168.0.3:443 {
-			transport http {
-				tls_server_name dns.hchu.me
-			}
-		}
-	}
-	respond 404
 }

--- a/docs/runbooks/proxmox-lxc-cutover.md
+++ b/docs/runbooks/proxmox-lxc-cutover.md
@@ -22,9 +22,9 @@
 
 ## Encrypted DNS Cutover
 
-1. Forward TCP `853` to `192.168.0.3` only if public DoT is required.
-2. Forward UDP `853` to `192.168.0.3` only if public DoQ is required.
-3. Confirm AdGuard has a valid `dns.hchu.me` certificate.
+1. Do not publish a public DoH endpoint.
+2. Keep AdGuard encrypted DNS ports private to LAN/Tailscale unless public DoT/DoQ is intentionally re-enabled later.
+3. Confirm AdGuard has a valid `adguard.home.hchu.me` certificate for private HTTPS upstreams.
 
 ## Downloads Cutover
 

--- a/infra/ansible/inventory/prod/group_vars/svc_dns.yml
+++ b/infra/ansible/inventory/prod/group_vars/svc_dns.yml
@@ -5,13 +5,22 @@ adguard_install_dir: /opt/adguardhome
 adguard_work_dir: /opt/adguardhome/work
 adguard_conf_dir: /opt/adguardhome/conf
 adguard_tls_dir: /opt/adguardhome/tls
-adguard_cert_domain: dns.hchu.me
+adguard_cert_domain: adguard.home.hchu.me
 adguard_admin_username: admin
 adguard_admin_port: 80
 adguard_https_port: 443
 adguard_dns_port: 53
 adguard_dot_port: 853
 adguard_acme_interval_seconds: 43200
+adguard_upstream_dns:
+  - tls://1.1.1.1
+  - tls://1.0.0.1
+adguard_bootstrap_dns:
+  - 1.1.1.1
+  - 1.0.0.1
+adguard_fallback_dns:
+  - 1.1.1.1
+  - 1.0.0.1
 adguard_trusted_proxies:
   - 127.0.0.0/8
   - ::1/128

--- a/infra/ansible/roles/adguard/tasks/main.yml
+++ b/infra/ansible/roles/adguard/tasks/main.yml
@@ -232,7 +232,7 @@
   no_log: true
   notify: Restart adguardhome
 
-- name: Update AdGuard trusted proxies and DNS filters in existing config
+- name: Update AdGuard DNS, TLS, trusted proxies, and filters in existing config
   ansible.builtin.command:
     argv:
       - python3
@@ -245,9 +245,23 @@
         path = Path(sys.argv[1])
         trusted_proxies = json.loads(sys.argv[2])
         dns_filters = json.loads(sys.argv[3])
+        upstream_dns = json.loads(sys.argv[4])
+        bootstrap_dns = json.loads(sys.argv[5])
+        fallback_dns = json.loads(sys.argv[6])
+        tls_config = json.loads(sys.argv[7])
 
         def yaml_quote(value):
             return '"' + str(value).replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+        def yaml_scalar(value):
+            if isinstance(value, bool):
+                return str(value).lower()
+            return str(value)
+
+        def nested_list_lines(key, values):
+            lines = [f"  {key}:"]
+            lines.extend(f"    - {value}" for value in values)
+            return lines
 
         def replace_top_level_block(lines, key, replacement):
             marker = f"{key}:"
@@ -307,6 +321,23 @@
         trusted_proxy_lines = ["  trusted_proxies:"]
         trusted_proxy_lines.extend(f"    - {proxy}" for proxy in trusted_proxies)
 
+        upstream_dns_lines = nested_list_lines("upstream_dns", upstream_dns)
+        bootstrap_dns_lines = nested_list_lines("bootstrap_dns", bootstrap_dns)
+        fallback_dns_lines = nested_list_lines("fallback_dns", fallback_dns)
+
+        tls_lines = ["tls:"]
+        for key in (
+            "enabled",
+            "server_name",
+            "force_https",
+            "port_https",
+            "port_dns_over_tls",
+            "port_dns_over_quic",
+            "certificate_path",
+            "private_key_path",
+        ):
+            tls_lines.append(f"  {key}: {yaml_scalar(tls_config[key])}")
+
         filter_lines = ["filters:"]
         for dns_filter in dns_filters:
             enabled = str(dns_filter.get("enabled", True)).lower()
@@ -325,6 +356,14 @@
             lines, "dns", "trusted_proxies", trusted_proxy_lines
         )
         changed = changed or block_changed
+        lines, block_changed = replace_nested_block(lines, "dns", "upstream_dns", upstream_dns_lines)
+        changed = changed or block_changed
+        lines, block_changed = replace_nested_block(lines, "dns", "bootstrap_dns", bootstrap_dns_lines)
+        changed = changed or block_changed
+        lines, block_changed = replace_nested_block(lines, "dns", "fallback_dns", fallback_dns_lines)
+        changed = changed or block_changed
+        lines, block_changed = replace_top_level_block(lines, "tls", tls_lines)
+        changed = changed or block_changed
         lines, block_changed = replace_top_level_block(lines, "filters", filter_lines)
         changed = changed or block_changed
 
@@ -336,9 +375,23 @@
       - "{{ adguard_conf_dir }}/AdGuardHome.yaml"
       - "{{ adguard_trusted_proxies | to_json }}"
       - "{{ adguard_dns_filters | to_json }}"
+      - "{{ adguard_upstream_dns | to_json }}"
+      - "{{ adguard_bootstrap_dns | to_json }}"
+      - "{{ adguard_fallback_dns | to_json }}"
+      - "{{ adguard_tls_config | to_json }}"
   register: adguard_proxy_filter_config
   changed_when: adguard_proxy_filter_config.stdout == "changed"
   notify: Restart adguardhome
+  vars:
+    adguard_tls_config:
+      enabled: true
+      server_name: "{{ adguard_cert_domain }}"
+      force_https: false
+      port_https: "{{ adguard_https_port }}"
+      port_dns_over_tls: "{{ adguard_dot_port }}"
+      port_dns_over_quic: "{{ adguard_dot_port }}"
+      certificate_path: "{{ adguard_tls_dir }}/fullchain.pem"
+      private_key_path: "{{ adguard_tls_dir }}/privkey.pem"
 
 - name: Install AdGuard OpenRC service
   ansible.builtin.template:

--- a/infra/ansible/roles/adguard/templates/AdGuardHome.yaml.j2
+++ b/infra/ansible/roles/adguard/templates/AdGuardHome.yaml.j2
@@ -34,11 +34,17 @@ dns:
   anonymize_client_ip: false
   ratelimit: 20
   upstream_dns:
-    - https://dns10.quad9.net/dns-query
-    - https://cloudflare-dns.com/dns-query
+{% for upstream in adguard_upstream_dns %}
+    - {{ upstream }}
+{% endfor %}
   bootstrap_dns:
-    - 1.1.1.1
-    - 9.9.9.9
+{% for bootstrap in adguard_bootstrap_dns %}
+    - {{ bootstrap }}
+{% endfor %}
+  fallback_dns:
+{% for fallback in adguard_fallback_dns %}
+    - {{ fallback }}
+{% endfor %}
   upstream_mode: load_balance
   cache_optimistic_answer_ttl: 30s
   cache_optimistic_max_age: 12h

--- a/tests/dns/test_adguard_acme_script.py
+++ b/tests/dns/test_adguard_acme_script.py
@@ -8,6 +8,8 @@ def test_adguard_acme_script_is_noninteractive():
 
     assert "--accept-tos" in script
     assert "run || lego" not in script
+    assert "ADGUARD_CERT_DOMAIN:-adguard.home.hchu.me" in script
+    assert "ADGUARD_CERT_DOMAIN:-dns.hchu.me" not in script
 
 
 def test_adguard_acme_restart_failure_is_not_hidden_when_service_exists():

--- a/tests/dns/test_adguard_config_template.py
+++ b/tests/dns/test_adguard_config_template.py
@@ -18,11 +18,14 @@ def render_adguard_config():
     return template.render(
         adguard_admin_password_hash="hash",
         adguard_admin_username="holybaechu",
-        adguard_cert_domain="dns.hchu.me",
+        adguard_cert_domain="adguard.home.hchu.me",
         adguard_dns_port=53,
         adguard_dot_port=853,
         adguard_https_port=443,
         adguard_admin_port=80,
+        adguard_upstream_dns=["tls://1.1.1.1", "tls://1.0.0.1"],
+        adguard_bootstrap_dns=["1.1.1.1", "1.0.0.1"],
+        adguard_fallback_dns=["1.1.1.1", "1.0.0.1"],
         adguard_tls_dir="/opt/adguardhome/tls",
         adguard_work_dir="/opt/adguardhome/work",
         adguard_trusted_proxies=["192.168.0.4/32"],
@@ -43,7 +46,7 @@ def test_adguard_baseline_config_uses_current_schema_for_bootstrap_dns():
     rendered = render_adguard_config()
 
     assert "schema_version: 34" in rendered
-    assert "bootstrap_dns:\n    - 1.1.1.1\n    - 9.9.9.9" in rendered
+    assert "bootstrap_dns:\n    - 1.1.1.1\n    - 1.0.0.1" in rendered
     assert "bootstrap_dns:\n    - - 1.1.1.1" not in rendered
 
 
@@ -90,3 +93,21 @@ def test_adguard_uses_hagezi_pro_blocklist_instead_of_default_filter():
     assert "id: 48" in rendered
     assert "AdGuard DNS filter" not in rendered
     assert "filter_1.txt" not in rendered
+
+
+def test_adguard_baseline_config_does_not_enable_public_encrypted_dns():
+    rendered = render_adguard_config()
+
+    assert "server_name: dns.hchu.me" not in rendered
+    assert "server_name: adguard.home.hchu.me" in rendered
+    assert "certificate_path: /opt/adguardhome/tls/fullchain.pem" in rendered
+    assert "private_key_path: /opt/adguardhome/tls/privkey.pem" in rendered
+
+
+def test_adguard_uses_cloudflare_tls_upstreams_with_plain_dns_fallbacks():
+    rendered = render_adguard_config()
+
+    assert "upstream_dns:\n    - tls://1.1.1.1\n    - tls://1.0.0.1" in rendered
+    assert "fallback_dns:\n    - 1.1.1.1\n    - 1.0.0.1" in rendered
+    assert "https://dns10.quad9.net/dns-query" not in rendered
+    assert "https://cloudflare-dns.com/dns-query" not in rendered

--- a/tests/dns/test_adguard_role.py
+++ b/tests/dns/test_adguard_role.py
@@ -180,7 +180,41 @@ def test_adguard_role_updates_trusted_proxies_and_filters_in_existing_config():
     assert "HaGeZi's Pro Blocklist" in dns_vars
     assert "filter_48.txt" in dns_vars
     assert "AdGuard DNS filter" not in dns_vars
-    assert "Update AdGuard trusted proxies and DNS filters in existing config" in tasks
+    assert "Update AdGuard DNS, TLS, trusted proxies, and filters in existing config" in tasks
     assert "adguard_trusted_proxies | to_json" in tasks
     assert "adguard_dns_filters | to_json" in tasks
+
+
+def test_adguard_role_updates_upstreams_fallbacks_and_tls_in_existing_config():
+    tasks = (
+        REPO_ROOT
+        / "infra"
+        / "ansible"
+        / "roles"
+        / "adguard"
+        / "tasks"
+        / "main.yml"
+    ).read_text(encoding="utf-8")
+    dns_vars = (
+        REPO_ROOT
+        / "infra"
+        / "ansible"
+        / "inventory"
+        / "prod"
+        / "group_vars"
+        / "svc_dns.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "adguard_upstream_dns:" in dns_vars
+    assert "  - tls://1.1.1.1" in dns_vars
+    assert "  - tls://1.0.0.1" in dns_vars
+    assert "adguard_fallback_dns:" in dns_vars
+    assert "adguard_bootstrap_dns:" in dns_vars
+    assert "adguard_upstream_dns | to_json" in tasks
+    assert "adguard_bootstrap_dns | to_json" in tasks
+    assert "adguard_fallback_dns | to_json" in tasks
+    assert "adguard_tls_config | to_json" in tasks
+    assert 'replace_nested_block(lines, "dns", "upstream_dns", upstream_dns_lines)' in tasks
+    assert 'replace_nested_block(lines, "dns", "fallback_dns", fallback_dns_lines)' in tasks
+    assert 'replace_top_level_block(lines, "tls", tls_lines)' in tasks
 

--- a/tests/dns/test_no_public_encrypted_dns.py
+++ b/tests/dns/test_no_public_encrypted_dns.py
@@ -1,0 +1,29 @@
+from tests.helpers import REPO_ROOT
+
+
+def test_edge_caddyfile_does_not_expose_public_dns_hostname_or_doh_route():
+    caddyfile = (REPO_ROOT / "apps" / "edge" / "Caddyfile").read_text(
+        encoding="utf-8"
+    )
+
+    assert "dns.hchu.me {" not in caddyfile
+    assert "handle /dns-query" not in caddyfile
+    assert "tls_server_name dns.hchu.me" not in caddyfile
+
+
+def test_dns_playbook_uses_private_adguard_certificate_name():
+    site = (REPO_ROOT / "infra" / "ansible" / "playbooks" / "site.yml").read_text(
+        encoding="utf-8"
+    )
+    dns_vars = (
+        REPO_ROOT / "infra" / "ansible" / "inventory" / "prod" / "group_vars" / "svc_dns.yml"
+    ).read_text(encoding="utf-8")
+    acme_script = (
+        REPO_ROOT / "apps" / "dns" / "acme" / "renew-adguard-cert.sh"
+    ).read_text(encoding="utf-8")
+
+    assert "adguard_acme" in site
+    assert "adguard_cert_domain: adguard.home.hchu.me" in dns_vars
+    assert "adguard_cert_domain: dns.hchu.me" not in dns_vars
+    assert "ADGUARD_CERT_DOMAIN:-adguard.home.hchu.me" in acme_script
+    assert "ADGUARD_CERT_DOMAIN:-dns.hchu.me" not in acme_script

--- a/tests/edge/test_caddyfile.py
+++ b/tests/edge/test_caddyfile.py
@@ -6,7 +6,8 @@ def test_caddyfile_is_tracked_and_uses_current_lxc_ips():
     content = caddyfile.read_text(encoding="utf-8")
 
     assert "reverse_proxy 192.168.0.7:3923" in content
-    assert "reverse_proxy 192.168.0.3:80" in content
+    assert "reverse_proxy https://192.168.0.3:443" in content
+    assert "reverse_proxy 192.168.0.3:80" not in content
     assert "reverse_proxy 192.168.0.6:8080" in content
     assert "reverse_proxy https://192.168.0.2:8006" in content
     assert "192.168.0.14" not in content
@@ -28,9 +29,8 @@ def test_proxmox_route_allows_same_origin_frames_for_web_shell():
 def test_router_route_omits_nosniff_for_mislabelled_flutter_assets():
     caddyfile = REPO_ROOT / "apps" / "edge" / "Caddyfile"
     content = caddyfile.read_text(encoding="utf-8")
-    router_block = content.split("router.home.hchu.me {", maxsplit=1)[1].split(
-        "dns.hchu.me {", maxsplit=1
-    )[0]
+    router_tail = content.split("router.home.hchu.me {", maxsplit=1)[1]
+    router_block = router_tail.split("dns.hchu.me {", maxsplit=1)[0]
 
     assert "(router_headers)" in content
     assert "import router_headers" in router_block
@@ -44,13 +44,21 @@ def test_router_route_omits_nosniff_for_mislabelled_flutter_assets():
     assert 'X-Frame-Options "DENY"' in router_headers
 
 
+def test_public_doh_route_is_not_exposed_by_edge():
+    content = (REPO_ROOT / "apps" / "edge" / "Caddyfile").read_text(encoding="utf-8")
+
+    assert "dns.hchu.me {" not in content
+    assert "handle /dns-query" not in content
+    assert "tls_server_name dns.hchu.me" not in content
+
+
 def test_copyparty_route_is_private_only_and_tls_upstreams_are_verified():
     content = (REPO_ROOT / "apps" / "edge" / "Caddyfile").read_text(encoding="utf-8")
     copyparty = content.split("copyparty.hchu.me {", maxsplit=1)[1].split("adguard.home.hchu.me {", maxsplit=1)[0]
 
     assert "import private_only" in copyparty
     assert "tls_insecure_skip_verify" not in content
-    assert "tls_server_name dns.hchu.me" in content
+    assert "tls_server_name adguard.home.hchu.me" in content
     assert "tls_server_name pve.home.hchu.me" in content
     assert "tls_trusted_ca_certs /etc/ssl/certs/homelab-pve-root-ca.pem" in content
 


### PR DESCRIPTION
## Summary
- Remove the public `dns.hchu.me` Caddy DoH route.
- Move AdGuard certificate/server name to `adguard.home.hchu.me` and proxy the private AdGuard route to HTTPS upstream.
- Switch AdGuard upstream DNS to Cloudflare DoT (`tls://1.1.1.1`, `tls://1.0.0.1`) with plain DNS bootstrap/fallback (`1.1.1.1`, `1.0.0.1`).
- Ensure the Ansible role updates existing AdGuard configs for upstream/bootstrap/fallback DNS and TLS settings, not just new baseline configs.

## Test Plan
- [x] Added failing tests first for removing public DoH and the new AdGuard DNS/TLS settings.
- [x] `PYTHONPATH=$PWD /tmp/homelab-analysis-venv/bin/python -m pytest -q`
- [x] `ANSIBLE_CONFIG=infra/ansible/ansible.cfg /tmp/homelab-analysis-venv/bin/ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/bootstrap.yml --syntax-check`
- [x] `ANSIBLE_CONFIG=infra/ansible/ansible.cfg /tmp/homelab-analysis-venv/bin/ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/site.yml --syntax-check`
- [x] `ANSIBLE_CONFIG=infra/ansible/ansible.cfg /tmp/homelab-analysis-venv/bin/ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/validate.yml --syntax-check`
- [x] `tofu init -backend=false -input=false && tofu fmt -recursive -check ../.. && tofu validate`
- [x] `sh -n` for tracked shell scripts
- [x] `compileall` for apps/scripts/tests
- [x] `git diff --check`

Note: local Caddy runtime validation was skipped because `caddy` is not installed in this runner.
