### PR TITLE
fix: harden homelab service surfaces

### DIFF
--- a/infra/ansible/inventory/prod/group_vars/all.yml
+++ b/infra/ansible/inventory/prod/group_vars/all.yml
@@ -4,13 +4,13 @@ homelab_lan_cidr: 192.168.0.0/24
 homelab_tailscale_cidr: 100.64.0.0/10
 homelab_timezone: Asia/Seoul
 
-edge_ip: 192.168.0.4
-dns_ip: 192.168.0.3
-tailnet_ip: 192.168.0.5
-downloads_ip: 192.168.0.6
-files_ip: 192.168.0.7
-minecraft_ip: 192.168.0.8
-hermes_ip: 192.168.0.9
+edge_ip: "{{ hostvars['edge'].ansible_host }}"
+dns_ip: "{{ hostvars['dns'].ansible_host }}"
+tailnet_ip: "{{ hostvars['tailnet'].ansible_host }}"
+downloads_ip: "{{ hostvars['downloads'].ansible_host }}"
+files_ip: "{{ hostvars['files'].ansible_host }}"
+minecraft_ip: "{{ hostvars['minecraft'].ansible_host }}"
+hermes_ip: "{{ hostvars['hermes'].ansible_host }}"
 
 service_user: homelab
 service_group: homelab

--- a/infra/ansible/inventory/prod/group_vars/svc_dns.yml
+++ b/infra/ansible/inventory/prod/group_vars/svc_dns.yml
@@ -1,6 +1,7 @@
 # renovate: datasource=github-releases depName=AdguardTeam/AdGuardHome versioning=semver extractVersion=^v(?<version>.*)$
 adguard_version: "v0.107.77"
 adguard_arch: "linux_amd64"
+adguard_sha256: 9d77af61881fbcef04ba50d53fa80af16ce8dd9b02fdb4faea154b741d08c72b
 adguard_install_dir: /opt/adguardhome
 adguard_work_dir: /opt/adguardhome/work
 adguard_conf_dir: /opt/adguardhome/conf

--- a/infra/ansible/inventory/prod/hosts.yml
+++ b/infra/ansible/inventory/prod/hosts.yml
@@ -8,10 +8,10 @@ all:
           ansible_host: 192.168.0.2
     alpine:
       hosts:
-        edge:
-          ansible_host: 192.168.0.4
         dns:
           ansible_host: 192.168.0.3
+        edge:
+          ansible_host: 192.168.0.4
         files:
           ansible_host: 192.168.0.7
     debian:
@@ -24,12 +24,12 @@ all:
           ansible_host: 192.168.0.8
         hermes:
           ansible_host: 192.168.0.9
-    svc_edge:
-      hosts:
-        edge:
     svc_dns:
       hosts:
         dns:
+    svc_edge:
+      hosts:
+        edge:
     svc_tailnet:
       hosts:
         tailnet:

--- a/infra/ansible/playbooks/validate.yml
+++ b/infra/ansible/playbooks/validate.yml
@@ -1,4 +1,25 @@
 ---
+- name: Validate Proxmox LXC root-only settings
+  hosts: pve_hosts
+  gather_facts: false
+  tasks:
+    - name: Validate root-only LXC settings match inventory
+      ansible.builtin.shell: |
+        set -eu
+        config="$(pct config "{{ item.vmid }}")"
+        {% for setting in item.settings %}
+        if ! printf '%s\n' "${config}" | grep -Eq '{{ setting.pattern }}'; then
+          printf 'Missing {{ setting.description }} on {{ item.name }} ({{ item.vmid }})\n' >&2
+          exit 1
+        fi
+        {% endfor %}
+      args:
+        executable: /bin/sh
+      changed_when: false
+      loop: "{{ pve_lxc_root_options }}"
+      loop_control:
+        label: "{{ item.name }} ({{ item.vmid }})"
+
 - name: Validate edge
   hosts: svc_edge
   gather_facts: false

--- a/infra/ansible/roles/adguard/tasks/main.yml
+++ b/infra/ansible/roles/adguard/tasks/main.yml
@@ -52,6 +52,7 @@
   ansible.builtin.get_url:
     url: "https://github.com/AdguardTeam/AdGuardHome/releases/download/{{ adguard_version }}/AdGuardHome_{{ adguard_arch }}.tar.gz"
     dest: "/tmp/AdGuardHome_{{ adguard_version }}_{{ adguard_arch }}.tar.gz"
+    checksum: "sha256:{{ adguard_sha256 }}"
     mode: "0644"
 
 - name: Extract AdGuard Home

--- a/infra/ansible/roles/caddy/tasks/main.yml
+++ b/infra/ansible/roles/caddy/tasks/main.yml
@@ -12,6 +12,9 @@
   ansible.builtin.command:
     cmd: "go install github.com/caddyserver/xcaddy/cmd/xcaddy@{{ xcaddy_version }}"
     creates: "/root/go/bin/xcaddy-{{ xcaddy_version }}.stamp"
+  environment:
+    GOSUMDB: sum.golang.org
+    GONOSUMDB: ""
 
 - name: Stamp xcaddy version
   ansible.builtin.copy:
@@ -31,6 +34,9 @@
     cmd: "/root/go/bin/xcaddy build {{ caddy_version }} --with {{ caddy_cloudflare_module }} --output {{ caddy_build_output }}"
     chdir: /tmp
     creates: "{{ caddy_build_output }}"
+  environment:
+    GOSUMDB: sum.golang.org
+    GONOSUMDB: ""
 
 - name: Install Caddy binary
   ansible.builtin.copy:

--- a/infra/ansible/roles/common_alpine/handlers/main.yml
+++ b/infra/ansible/roles/common_alpine/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Restart Alpine sshd
+  ansible.builtin.service:
+    name: sshd
+    state: restarted

--- a/infra/ansible/roles/common_alpine/tasks/main.yml
+++ b/infra/ansible/roles/common_alpine/tasks/main.yml
@@ -32,3 +32,16 @@
     shell: /sbin/nologin
     create_home: false
     state: present
+
+- name: Configure Alpine SSH hardening
+  ansible.builtin.lineinfile:
+    path: /etc/ssh/sshd_config
+    regexp: '^#?{{ item.split()[0] }}\s+'
+    line: "{{ item }}"
+    validate: /usr/sbin/sshd -t -f %s
+  loop:
+    - PasswordAuthentication no
+    - KbdInteractiveAuthentication no
+    - ChallengeResponseAuthentication no
+    - PermitRootLogin prohibit-password
+  notify: Restart Alpine sshd

--- a/infra/ansible/roles/common_debian/handlers/main.yml
+++ b/infra/ansible/roles/common_debian/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Restart Debian ssh
+  ansible.builtin.service:
+    name: ssh
+    state: restarted

--- a/infra/ansible/roles/common_debian/tasks/main.yml
+++ b/infra/ansible/roles/common_debian/tasks/main.yml
@@ -23,3 +23,16 @@
     shell: /usr/sbin/nologin
     create_home: false
     state: present
+
+- name: Configure Debian SSH hardening
+  ansible.builtin.lineinfile:
+    path: /etc/ssh/sshd_config
+    regexp: '^#?{{ item.split()[0] }}\s+'
+    line: "{{ item }}"
+    validate: /usr/sbin/sshd -t -f %s
+  loop:
+    - PasswordAuthentication no
+    - KbdInteractiveAuthentication no
+    - ChallengeResponseAuthentication no
+    - PermitRootLogin prohibit-password
+  notify: Restart Debian ssh

--- a/infra/ansible/roles/copyparty/handlers/main.yml
+++ b/infra/ansible/roles/copyparty/handlers/main.yml
@@ -3,3 +3,8 @@
   ansible.builtin.service:
     name: copyparty
     state: restarted
+
+- name: Restart copyparty nftables
+  ansible.builtin.service:
+    name: nftables
+    state: restarted

--- a/infra/ansible/roles/copyparty/tasks/main.yml
+++ b/infra/ansible/roles/copyparty/tasks/main.yml
@@ -6,6 +6,7 @@
       - py3-pip
       - py3-virtualenv
       - ffmpeg
+      - nftables
     update_cache: true
     state: present
 
@@ -68,6 +69,22 @@
     mode: "0600"
   no_log: true
   notify: Restart copyparty
+
+- name: Install Copyparty nftables config
+  ansible.builtin.template:
+    src: nftables.conf.j2
+    dest: /etc/nftables.nft
+    owner: root
+    group: root
+    mode: "0600"
+    validate: nft -c -f %s
+  notify: Restart copyparty nftables
+
+- name: Enable Copyparty nftables
+  ansible.builtin.service:
+    name: nftables
+    enabled: true
+    state: started
 
 - name: Install Copyparty OpenRC service
   ansible.builtin.template:

--- a/infra/ansible/roles/copyparty/templates/nftables.conf.j2
+++ b/infra/ansible/roles/copyparty/templates/nftables.conf.j2
@@ -25,14 +25,9 @@ table inet filter {
     } ip6 hoplimit 255 accept
 
     ip saddr { {{ homelab_lan_cidr }}, {{ homelab_tailscale_cidr }} } tcp dport 22 accept
-    ip saddr { {{ homelab_lan_cidr }}, {{ homelab_tailscale_cidr }} } udp dport {{ adguard_dns_port }} accept
-    ip saddr { {{ homelab_lan_cidr }}, {{ homelab_tailscale_cidr }} } tcp dport {{ adguard_dns_port }} accept
-    ip saddr { {{ homelab_lan_cidr }}, {{ homelab_tailscale_cidr }} } tcp dport {{ adguard_dot_port }} accept
-    ip saddr { {{ homelab_lan_cidr }}, {{ homelab_tailscale_cidr }} } udp dport {{ adguard_dot_port }} accept
-    ip saddr {{ edge_ip }} tcp dport {{ adguard_https_port }} accept
-
-    ip saddr {{ edge_ip }} tcp dport {{ adguard_admin_port }} accept
-    tcp dport {{ adguard_admin_port }} reject
+    ip saddr {{ edge_ip }} tcp dport {{ copyparty_listen_port }} accept
+    ip saddr {{ homelab_tailscale_cidr }} tcp dport {{ copyparty_listen_port }} accept
+    tcp dport {{ copyparty_listen_port }} reject
   }
 
   chain forward {

--- a/scripts/ci/check_tofu_plan_safe.py
+++ b/scripts/ci/check_tofu_plan_safe.py
@@ -9,6 +9,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from homelab_topology import expected_lxc_count
+
 LXC_RESOURCE_SUFFIX = ".proxmox_virtual_environment_container.this"
 
 
@@ -56,6 +58,13 @@ def _create_only_lxc_changes(plan: dict[str, Any]) -> list[str]:
     return create_only
 
 
+def _expected_lxc_count() -> int:
+    configured = os.environ.get("TOFU_EXPECTED_LXC_COUNT")
+    if configured:
+        return int(configured)
+    return expected_lxc_count()
+
+
 def main(argv: list[str]) -> int:
     plan = _load_plan(argv)
     destructive = _destructive_changes(plan)
@@ -77,8 +86,8 @@ def main(argv: list[str]) -> int:
         return 1
 
     create_only_lxcs = _create_only_lxc_changes(plan)
-    expected_lxc_count = int(os.environ.get("TOFU_EXPECTED_LXC_COUNT", "7"))
-    if len(create_only_lxcs) >= expected_lxc_count and not _truthy(
+    expected_lxcs = _expected_lxc_count()
+    if len(create_only_lxcs) >= expected_lxcs and not _truthy(
         os.environ.get("ALLOW_EMPTY_STATE_BOOTSTRAP")
     ):
         print("OpenTofu plan appears to be a create-only LXC bootstrap plan:", file=sys.stderr)

--- a/scripts/ci/homelab_topology.py
+++ b/scripts/ci/homelab_topology.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Shared helpers for the committed homelab container topology."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+TOPOLOGY = ROOT / "infra" / "opentofu" / "envs" / "prod" / "containers.auto.tfvars"
+
+
+def _parse_value(body: str, key: str) -> str:
+    match = re.search(rf'^\s*{key}\s*=\s*"?([^"\n]+)"?\s*$', body, re.MULTILINE)
+    if not match:
+        raise ValueError(f"missing {key} in container block")
+    return match.group(1)
+
+
+def load_containers(path: Path = TOPOLOGY) -> dict[str, dict[str, Any]]:
+    text = path.read_text(encoding="utf-8")
+    containers: dict[str, dict[str, Any]] = {}
+    for match in re.finditer(
+        r"^\s{2}([a-z0-9_-]+)\s*=\s*\{(.*?)^\s{2}\}",
+        text,
+        re.MULTILINE | re.DOTALL,
+    ):
+        name, body = match.groups()
+        containers[name] = {
+            "hostname": _parse_value(body, "hostname"),
+            "os_type": _parse_value(body, "os_type"),
+            "ip_address": _parse_value(body, "ip_address").split("/", 1)[0],
+            "startup_order": int(_parse_value(body, "startup_order")),
+        }
+
+    if not containers:
+        raise ValueError(f"no containers found in {path}")
+
+    duplicate_orders = sorted(
+        order
+        for order in {container["startup_order"] for container in containers.values()}
+        if sum(1 for container in containers.values() if container["startup_order"] == order) > 1
+    )
+    if duplicate_orders:
+        raise ValueError(f"duplicate startup_order values: {duplicate_orders}")
+
+    return containers
+
+
+def service_names(containers: dict[str, dict[str, Any]] | None = None) -> list[str]:
+    containers = containers or load_containers()
+    return sorted(containers, key=lambda name: containers[name]["startup_order"])
+
+
+def expected_lxc_count(path: Path = TOPOLOGY) -> int:
+    return len(load_containers(path))

--- a/scripts/ci/render_ansible_inventory.py
+++ b/scripts/ci/render_ansible_inventory.py
@@ -4,45 +4,16 @@
 from __future__ import annotations
 
 import argparse
-import re
 import sys
 from pathlib import Path
-from typing import Any
 
-ROOT = Path(__file__).resolve().parents[2]
-TOPOLOGY = ROOT / "infra" / "opentofu" / "envs" / "prod" / "containers.auto.tfvars"
+from homelab_topology import ROOT, load_containers, service_names
+
 INVENTORY = ROOT / "infra" / "ansible" / "inventory" / "prod" / "hosts.yml"
-SERVICE_ORDER = ["edge", "dns", "tailnet", "downloads", "files", "minecraft", "hermes"]
 
 
-def _parse_value(body: str, key: str) -> str:
-    match = re.search(rf'^\s*{key}\s*=\s*"?([^"\n]+)"?\s*$', body, re.MULTILINE)
-    if not match:
-        raise ValueError(f"missing {key} in container block")
-    return match.group(1)
-
-
-def load_containers(path: Path = TOPOLOGY) -> dict[str, dict[str, Any]]:
-    text = path.read_text(encoding="utf-8")
-    containers: dict[str, dict[str, Any]] = {}
-    for match in re.finditer(
-        r"^\s{2}([a-z0-9_-]+)\s*=\s*\{(.*?)^\s{2}\}",
-        text,
-        re.MULTILINE | re.DOTALL,
-    ):
-        name, body = match.groups()
-        containers[name] = {
-            "hostname": _parse_value(body, "hostname"),
-            "os_type": _parse_value(body, "os_type"),
-            "ip_address": _parse_value(body, "ip_address").split("/", 1)[0],
-        }
-    missing = [name for name in SERVICE_ORDER if name not in containers]
-    if missing:
-        raise ValueError(f"missing containers: {', '.join(missing)}")
-    return containers
-
-
-def render_inventory(containers: dict[str, dict[str, Any]]) -> str:
+def render_inventory(containers: dict[str, dict[str, object]]) -> str:
+    names = service_names(containers)
     lines = [
         "all:",
         "  vars:",
@@ -55,10 +26,10 @@ def render_inventory(containers: dict[str, dict[str, Any]]) -> str:
     ]
     for os_type in ("alpine", "debian"):
         lines += [f"    {os_type}:", "      hosts:"]
-        for name in SERVICE_ORDER:
+        for name in names:
             if containers[name]["os_type"] == os_type:
                 lines += [f"        {name}:", f"          ansible_host: {containers[name]['ip_address']}"]
-    for name in SERVICE_ORDER:
+    for name in names:
         lines += [f"    svc_{name}:", "      hosts:", f"        {name}:"]
     return "\n".join(lines) + "\n"
 

--- a/scripts/ci/render_ansible_targets.py
+++ b/scripts/ci/render_ansible_targets.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Render service:group target pairs for parallel Ansible deploys."""
+
+from __future__ import annotations
+
+import sys
+
+from homelab_topology import load_containers, service_names
+
+
+def render_targets() -> str:
+    return " ".join(f"{name}:svc_{name}" for name in service_names(load_containers()))
+
+
+def main() -> int:
+    sys.stdout.write(render_targets())
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/run-ansible-parallel.sh
+++ b/scripts/ci/run-ansible-parallel.sh
@@ -13,8 +13,9 @@ fi
 mode="$1"
 shift
 
-inventory="infra/ansible/inventory/prod/hosts.yml"
-TARGETS="edge:svc_edge dns:svc_dns tailnet:svc_tailnet downloads:svc_downloads files:svc_files minecraft:svc_minecraft hermes:svc_hermes"
+repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+inventory="${repo_root}/infra/ansible/inventory/prod/hosts.yml"
+TARGETS="$(python3 "${repo_root}/scripts/ci/render_ansible_targets.py")"
 
 case "${mode}" in
   site)
@@ -29,6 +30,10 @@ case "${mode}" in
     ;;
 esac
 
+if [ "$mode" = "validate" ]; then
+  TARGETS="pve:pve_hosts ${TARGETS}"
+fi
+
 log_dir="$(mktemp -d)"
 pid_file="${log_dir}/pids"
 : > "${pid_file}"
@@ -42,7 +47,7 @@ for entry in ${TARGETS}; do
   target="${entry%%:*}"
   limit="${entry#*:}"
   (
-    ansible-playbook       -i "${inventory}"       "${playbook}"       --limit "${limit}"       "$@"
+    ansible-playbook       -i "${inventory}"       "${repo_root}/${playbook}"       --limit "${limit}"       "$@"
   ) > "${log_dir}/${target}.log" 2>&1 &
   printf '%s %s
 ' "$!" "${target}" >> "${pid_file}"

--- a/tests/dns/test_adguard_nftables_template.py
+++ b/tests/dns/test_adguard_nftables_template.py
@@ -30,9 +30,9 @@ def test_adguard_nftables_allows_ssh_and_limits_dns_service_ports():
     )
 
 
-def test_adguard_nftables_limits_admin_http_to_edge_and_tailnet():
+def test_adguard_nftables_limits_plain_admin_http_to_edge_only():
     rendered = render_adguard_nftables()
 
     assert "ip saddr 192.168.0.4 tcp dport 80 accept" in rendered
-    assert "ip saddr 100.64.0.0/10 tcp dport 80 accept" in rendered
+    assert "ip saddr 100.64.0.0/10 tcp dport 80 accept" not in rendered
     assert "tcp dport 80 reject" in rendered

--- a/tests/dns/test_adguard_role.py
+++ b/tests/dns/test_adguard_role.py
@@ -141,6 +141,7 @@ def test_adguard_role_uses_versioned_download_and_extract_paths():
     ).read_text(encoding="utf-8")
 
     assert 'dest: "/tmp/AdGuardHome_{{ adguard_version }}_{{ adguard_arch }}.tar.gz"' in tasks
+    assert 'checksum: "sha256:{{ adguard_sha256 }}"' in tasks
     assert 'path: "/tmp/AdGuardHome-{{ adguard_version }}"' in tasks
     assert 'src: "/tmp/AdGuardHome_{{ adguard_version }}_{{ adguard_arch }}.tar.gz"' in tasks
     assert 'creates: "/tmp/AdGuardHome-{{ adguard_version }}/AdGuardHome/AdGuardHome"' in tasks
@@ -223,6 +224,21 @@ def test_adguard_config_updater_collapses_existing_duplicate_fallback_dns(tmp_pa
     assert "  pending_requests:\n    enabled: true" in updated
 
 
+def test_adguard_release_checksum_is_pinned_in_inventory():
+    dns_vars = (
+        REPO_ROOT
+        / "infra"
+        / "ansible"
+        / "inventory"
+        / "prod"
+        / "group_vars"
+        / "svc_dns.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "adguard_sha256: 9d77af61881fbcef04ba50d53fa80af16ce8dd9b02fdb4faea154b741d08c72b" in dns_vars
+
+
+
 def test_adguard_role_hashes_plaintext_admin_password():
     tasks = (
         REPO_ROOT
@@ -266,7 +282,7 @@ def test_adguard_role_limits_plain_http_admin_ui_with_nftables():
     assert "Install AdGuard nftables config" in tasks
     assert "Enable AdGuard nftables" in tasks
     assert "ip saddr {{ edge_ip }} tcp dport {{ adguard_admin_port }} accept" in nftables
-    assert "ip saddr {{ homelab_tailscale_cidr }} tcp dport {{ adguard_admin_port }} accept" in nftables
+    assert "ip saddr {{ homelab_tailscale_cidr }} tcp dport {{ adguard_admin_port }} accept" not in nftables
     assert "tcp dport {{ adguard_admin_port }} reject" in nftables
 
 

--- a/tests/edge/test_caddy_openrc_template.py
+++ b/tests/edge/test_caddy_openrc_template.py
@@ -43,6 +43,8 @@ def test_caddy_build_is_reproducible_and_version_sensitive():
     assert "--output {{ caddy_build_output }}" in tasks
     assert "creates: \"{{ caddy_build_output }}\"" in tasks
     assert "xcaddy-{{ xcaddy_version }}.stamp" in tasks
+    assert "GOSUMDB: sum.golang.org" in tasks
+    assert "GONOSUMDB: \"\"" in tasks
     assert "creates: /tmp/caddy" not in tasks
 
 

--- a/tests/files/test_copyparty_nftables_template.py
+++ b/tests/files/test_copyparty_nftables_template.py
@@ -1,0 +1,34 @@
+from tests.helpers import REPO_ROOT, render_role_template
+
+
+def render_copyparty_nftables():
+    return render_role_template(
+        "copyparty",
+        "nftables.conf.j2",
+        copyparty_listen_port=3923,
+        edge_ip="192.168.0.4",
+        homelab_lan_cidr="192.168.0.0/24",
+        homelab_tailscale_cidr="100.64.0.0/10",
+    )
+
+
+def test_copyparty_nftables_allows_ssh_but_limits_service_port_to_edge_and_tailscale():
+    rendered = render_copyparty_nftables()
+
+    assert "type filter hook input priority 0; policy drop;" in rendered
+    assert "ip saddr { 192.168.0.0/24, 100.64.0.0/10 } tcp dport 22 accept" in rendered
+    assert "ip saddr 192.168.0.4 tcp dport 3923 accept" in rendered
+    assert "ip saddr 100.64.0.0/10 tcp dport 3923 accept" in rendered
+    assert "ip saddr 192.168.0.0/24 tcp dport 3923 accept" not in rendered
+    assert "tcp dport 3923 reject" in rendered
+
+
+def test_copyparty_role_installs_and_enables_nftables():
+    tasks = (REPO_ROOT / "infra" / "ansible" / "roles" / "copyparty" / "tasks" / "main.yml").read_text(encoding="utf-8")
+
+    assert "- nftables" in tasks
+    assert "Install Copyparty nftables config" in tasks
+    assert "src: nftables.conf.j2" in tasks
+    assert "dest: /etc/nftables.nft" in tasks
+    assert "validate: nft -c -f %s" in tasks
+    assert "Enable Copyparty nftables" in tasks

--- a/tests/hermes/test_hermes_infra.py
+++ b/tests/hermes/test_hermes_infra.py
@@ -59,7 +59,7 @@ def test_hermes_inventory_is_debian_host_and_role_group():
 def test_hermes_all_group_vars_define_ip_ids_bootstrap_and_mounts():
     all_vars = read("infra/ansible/inventory/prod/group_vars/all.yml")
 
-    assert re.search(r"^hermes_ip: 192\.168\.0\.9$", all_vars, re.MULTILINE)
+    assert re.search(r"^hermes_ip: \"\{\{ hostvars\['hermes'\]\.ansible_host \}\}\"$", all_vars, re.MULTILINE)
     assert re.search(r"^hermes_service_uid: 1200$", all_vars, re.MULTILINE)
     assert re.search(r"^hermes_service_gid: 1200$", all_vars, re.MULTILINE)
     assert "  - vmid: 116\n    name: hermes\n    os_family: debian" in all_vars

--- a/tests/infra/test_lxc_drift_validation.py
+++ b/tests/infra/test_lxc_drift_validation.py
@@ -1,0 +1,16 @@
+from tests.helpers import REPO_ROOT
+
+
+def test_validate_playbook_checks_root_only_lxc_option_drift_without_mutating():
+    validate = (REPO_ROOT / "infra" / "ansible" / "playbooks" / "validate.yml").read_text(encoding="utf-8")
+
+    assert "Validate Proxmox LXC root-only settings" in validate
+    assert "pct config" in validate
+    assert "pve_lxc_root_options" in validate
+    assert "grep -Eq '{{ setting.pattern }}'" in validate
+
+    drift_play = validate.split("- name: Validate Proxmox LXC root-only settings", maxsplit=1)[1].split("- name: Validate edge", maxsplit=1)[0]
+    assert "changed_when: false" in drift_play
+    assert "pct set" not in drift_play
+    assert "pct shutdown" not in drift_play
+    assert "pct stop" not in drift_play

--- a/tests/infra/test_ssh_hardening.py
+++ b/tests/infra/test_ssh_hardening.py
@@ -1,0 +1,35 @@
+from tests.helpers import REPO_ROOT
+
+
+HARDENING_LINES = (
+    "PasswordAuthentication no",
+    "KbdInteractiveAuthentication no",
+    "ChallengeResponseAuthentication no",
+    "PermitRootLogin prohibit-password",
+)
+
+
+def test_common_alpine_hardens_sshd_without_disabling_root_key_login():
+    tasks = (REPO_ROOT / "infra" / "ansible" / "roles" / "common_alpine" / "tasks" / "main.yml").read_text(encoding="utf-8")
+    handlers = (REPO_ROOT / "infra" / "ansible" / "roles" / "common_alpine" / "handlers" / "main.yml").read_text(encoding="utf-8")
+
+    assert "Configure Alpine SSH hardening" in tasks
+    assert "/etc/ssh/sshd_config" in tasks
+    for line in HARDENING_LINES:
+        assert line in tasks
+    assert "PermitRootLogin no" not in tasks
+    assert "Restart Alpine sshd" in handlers
+    assert "name: sshd" in handlers
+
+
+def test_common_debian_hardens_sshd_without_disabling_root_key_login():
+    tasks = (REPO_ROOT / "infra" / "ansible" / "roles" / "common_debian" / "tasks" / "main.yml").read_text(encoding="utf-8")
+    handlers = (REPO_ROOT / "infra" / "ansible" / "roles" / "common_debian" / "handlers" / "main.yml").read_text(encoding="utf-8")
+
+    assert "Configure Debian SSH hardening" in tasks
+    assert "/etc/ssh/sshd_config" in tasks
+    for line in HARDENING_LINES:
+        assert line in tasks
+    assert "PermitRootLogin no" not in tasks
+    assert "Restart Debian ssh" in handlers
+    assert "name: ssh" in handlers

--- a/tests/minecraft/test_minecraft_infra.py
+++ b/tests/minecraft/test_minecraft_infra.py
@@ -57,5 +57,5 @@ def test_minecraft_inventory_is_debian_host_and_role_group():
 def test_minecraft_ip_and_bootstrap_are_in_all_group_vars():
     all_vars = read("infra/ansible/inventory/prod/group_vars/all.yml")
 
-    assert re.search(r"^minecraft_ip: 192\.168\.0\.8$", all_vars, re.MULTILINE)
+    assert re.search(r"^minecraft_ip: \"\{\{ hostvars\['minecraft'\]\.ansible_host \}\}\"$", all_vars, re.MULTILINE)
     assert "  - vmid: 115\n    name: minecraft\n    os_family: debian" in all_vars

--- a/tests/repo/test_github_workflows.py
+++ b/tests/repo/test_github_workflows.py
@@ -65,16 +65,30 @@ def test_cd_workflow_parallelizes_service_deploy_and_validate():
     assert "ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/validate.yml" not in workflow
 
 
-def test_parallel_ansible_runner_limits_each_service_and_waits_for_failures():
+def test_parallel_ansible_runner_derives_service_targets_from_topology():
     runner = (REPO_ROOT / "scripts" / "ci" / "run-ansible-parallel.sh").read_text(
         encoding="utf-8"
     )
+    target_renderer = (REPO_ROOT / "scripts" / "ci" / "render_ansible_targets.py").read_text(
+        encoding="utf-8"
+    )
 
-    assert 'TARGETS="edge:svc_edge dns:svc_dns tailnet:svc_tailnet downloads:svc_downloads files:svc_files minecraft:svc_minecraft hermes:svc_hermes"' in runner
+    assert "scripts/ci/render_ansible_targets.py" in runner
+    assert 'TARGETS="edge:svc_edge dns:svc_dns tailnet:svc_tailnet downloads:svc_downloads files:svc_files minecraft:svc_minecraft hermes:svc_hermes"' not in runner
     assert '--limit "${limit}"' in runner
     assert " &" in runner
     assert "wait" in runner
     assert "failed=1" in runner
+    assert "load_containers" in target_renderer
+
+
+def test_parallel_validate_runner_includes_pve_drift_validation_target():
+    runner = (REPO_ROOT / "scripts" / "ci" / "run-ansible-parallel.sh").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'TARGETS="pve:pve_hosts ${TARGETS}"' in runner
+    assert 'mode" = "validate"' in runner
 
 
 def test_cd_workflow_configures_remote_tofu_state():

--- a/tests/repo/test_topology_single_source.py
+++ b/tests/repo/test_topology_single_source.py
@@ -1,0 +1,22 @@
+from tests.helpers import REPO_ROOT
+
+
+def test_ansible_ip_variables_are_derived_from_inventory_hostvars():
+    all_vars = (REPO_ROOT / "infra" / "ansible" / "inventory" / "prod" / "group_vars" / "all.yml").read_text(encoding="utf-8")
+
+    for service in ("edge", "dns", "tailnet", "downloads", "files", "minecraft", "hermes"):
+        assert f"{service}_ip: \"{{{{ hostvars['{service}'].ansible_host }}}}\"" in all_vars
+
+    assert "edge_ip: 192.168.0.4" not in all_vars
+    assert "dns_ip: 192.168.0.3" not in all_vars
+
+
+def test_topology_helper_is_shared_by_inventory_runner_and_plan_guard():
+    inventory = (REPO_ROOT / "scripts" / "ci" / "render_ansible_inventory.py").read_text(encoding="utf-8")
+    targets = (REPO_ROOT / "scripts" / "ci" / "render_ansible_targets.py").read_text(encoding="utf-8")
+    guard = (REPO_ROOT / "scripts" / "ci" / "check_tofu_plan_safe.py").read_text(encoding="utf-8")
+
+    assert "from homelab_topology import" in inventory
+    assert "from homelab_topology import" in targets
+    assert "from homelab_topology import expected_lxc_count" in guard
+    assert 'os.environ.get("TOFU_EXPECTED_LXC_COUNT", "7")' not in guard


### PR DESCRIPTION
## Summary
- Add a default-drop nftables policy to the files/Copyparty LXC so port 3923 is only reachable from edge and Tailscale, while preserving SSH from LAN/Tailscale.
- Tighten AdGuard direct access: private Caddy route continues over HTTPS, admin HTTP is no longer directly allowed from Tailscale, and AdGuard release downloads are SHA256-pinned.
- Reduce duplicated topology data by deriving inventory, parallel Ansible targets, and the OpenTofu create-only guard from the committed container topology.
- Add a validate-playbook drift check for Proxmox root-only LXC settings without mutating production state.
- Improve Caddy build reproducibility with version-sensitive outputs and Go checksum database settings.
- Harden common SSH configuration on Alpine/Debian LXCs without disabling root key-based deploy access.

## Requested items covered
- 2: Copyparty direct port exposure
- 3: AdGuard admin/upstream access
- 5: topology duplication
- 6: OpenTofu/Proxmox drift visibility
- 7: supply-chain/download/build hardening
- 8: root SSH baseline hardening

## Test Plan
- [x] `/tmp/homelab-verify-venv/bin/python -m pytest -q` → 188 passed
- [x] `ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/bootstrap.yml --syntax-check`
- [x] `ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/site.yml --syntax-check`
- [x] `ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/validate.yml --syntax-check`
- [x] `python scripts/ci/render_ansible_inventory.py --check`
- [x] `python scripts/ci/render_ansible_targets.py`
- [x] `compileall -q apps scripts tests`
- [x] `sh -n` for all tracked shell scripts
- [x] `tofu init -backend=false -input=false && tofu fmt -recursive -check ../.. && tofu validate`
- [x] `git diff --check`
- [x] Verified AdGuard v0.107.77 linux_amd64 tarball SHA256: `9d77af61881fbcef04ba50d53fa80af16ce8dd9b02fdb4faea154b741d08c72b`
