### PR TITLE
fix: validate AdGuard route without Via header

### DIFF
--- a/infra/ansible/playbooks/validate.yml
+++ b/infra/ansible/playbooks/validate.yml
@@ -54,7 +54,7 @@
           set -eu
           headers="$(curl -fsSI --http1.1 --resolve "adguard.home.hchu.me:443:{{ edge_ip }}" https://adguard.home.hchu.me/login.html)"
           printf '%s\n' "$headers" | grep -F "HTTP/1.1 200"
-          printf '%s\n' "$headers" | grep -F "Via: 1.1 Caddy"
+          printf '%s\n' "$headers" | grep -Fi "Strict-Transport-Security: max-age=31536000; includeSubDomains; preload"
         executable: /bin/sh
       changed_when: false
 

--- a/tests/edge/test_validate_playbook.py
+++ b/tests/edge/test_validate_playbook.py
@@ -17,7 +17,10 @@ def test_validate_playbook_checks_adguard_webui_uses_caddy_tls_route():
 
     assert '--resolve "adguard.home.hchu.me:443:{{ edge_ip }}"' in validate
     assert "https://adguard.home.hchu.me/login.html" in validate
-    assert "Via: 1.1 Caddy" in validate
+    assert (
+        "Strict-Transport-Security: max-age=31536000; includeSubDomains; preload"
+        in validate
+    )
 
 
 def test_validate_playbook_checks_private_home_dns_rewrite():


### PR DESCRIPTION
## Summary
- Fix CD validate failure in the AdGuard Caddy route check
- Replace the invalid `Via: 1.1 Caddy` assertion with the Caddy-managed HSTS header from `secure_headers`
- Keep the edge-IP `--resolve` and HTTPS 200 checks intact

## Root cause
Caddy does not emit a `Via: 1.1 Caddy` response header by default, so the live CD validation failed even though `https://adguard.home.hchu.me/login.html` returned `HTTP/1.1 200 OK` through the edge IP.

## Test plan
- `pytest tests/edge/test_validate_playbook.py -q`
- `pytest -q`
- `python3 scripts/ci/render_ansible_inventory.py --check`
- `ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/bootstrap.yml --syntax-check`
- `ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/site.yml --syntax-check`
- `ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/validate.yml --syntax-check`
- `python3 -m compileall -q apps scripts tests`
- `sh -n` for tracked shell scripts
- `tofu init -backend=false && tofu fmt -recursive -check ../.. && tofu validate`
- `git diff --check`