### PR TITLE
feat: configure Hermes web search backends

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -106,6 +106,8 @@ jobs:
           QBITTORRENT_WEBUI_PASSWORD: ${{ secrets.QBITTORRENT_WEBUI_PASSWORD }}
           HERMES_DISCORD_BOT_TOKEN: ${{ secrets.HERMES_DISCORD_BOT_TOKEN }}
           HERMES_DISCORD_ALLOWED_USERS: ${{ secrets.HERMES_DISCORD_ALLOWED_USERS }}
+          PARALLEL_API_KEY: ${{ secrets.PARALLEL_API_KEY }}
+          FIRECRAWL_API_KEY: ${{ secrets.FIRECRAWL_API_KEY }}
           COPYPARTY_USERS_JSON: ${{ secrets.COPYPARTY_USERS_JSON }}
         run: python3 scripts/ci/write_ansible_extra_vars.py "${ANSIBLE_EXTRA_VARS_PATH}"
 

--- a/docs/runbooks/hermes-agent-discord.md
+++ b/docs/runbooks/hermes-agent-discord.md
@@ -8,10 +8,27 @@ Set these GitHub Actions secrets in the `prod` environment:
 
 - `HERMES_DISCORD_BOT_TOKEN`: Discord bot token from the Discord Developer Portal.
 - `HERMES_DISCORD_ALLOWED_USERS`: comma-separated Discord user IDs allowed to use the bot.
+- `PARALLEL_API_KEY`: Parallel API key used by Hermes `web_search`.
+- `FIRECRAWL_API_KEY`: Firecrawl API key used by Hermes `web_extract`.
 
-The CD workflow writes them to Ansible as `hermes_discord_bot_token` and `hermes_discord_allowed_users`. Ansible renders Hermes' expected runtime names, `DISCORD_BOT_TOKEN` and `DISCORD_ALLOWED_USERS`, into `/etc/hermes-gateway.env`.
+The CD workflow writes them to Ansible as `hermes_discord_bot_token`, `hermes_discord_allowed_users`, `hermes_parallel_api_key`, and `hermes_firecrawl_api_key`. Ansible renders Hermes' expected runtime names into `/etc/hermes-gateway.env`:
 
-Provider/model API keys are not deployed by this repo. Complete provider/model setup from the Hermes CLI after the service is running.
+- `DISCORD_BOT_TOKEN`
+- `DISCORD_ALLOWED_USERS`
+- `PARALLEL_API_KEY`
+- `FIRECRAWL_API_KEY`
+
+## Web search
+
+This repo configures Hermes web tooling as:
+
+```yaml
+web:
+  search_backend: parallel
+  extract_backend: firecrawl
+```
+
+That gives Hermes Parallel-backed search results and Firecrawl-backed page extraction/scraping. The runtime config helper preserves the existing model/provider settings while enforcing these web backend settings.
 
 ## Discord setup
 

--- a/infra/ansible/inventory/prod/group_vars/svc_hermes.yml
+++ b/infra/ansible/inventory/prod/group_vars/svc_hermes.yml
@@ -14,6 +14,8 @@ hermes_agent_repo: https://github.com/NousResearch/hermes-agent.git
 hermes_agent_ref: 36ae958473b8530ffb1a395c4944b8cdbcae82fe
 
 hermes_auxiliary_compression_provider: main
+hermes_web_search_backend: parallel
+hermes_web_extract_backend: firecrawl
 
 hermes_discord_require_mention: true
 hermes_discord_ignore_no_mention: true

--- a/infra/ansible/roles/hermes/tasks/main.yml
+++ b/infra/ansible/roles/hermes/tasks/main.yml
@@ -1,12 +1,16 @@
 ---
-- name: Require Hermes Discord gateway secrets
+- name: Require Hermes Discord gateway and web backend secrets
   ansible.builtin.assert:
     that:
       - hermes_discord_bot_token is defined
       - hermes_discord_bot_token | length > 0
       - hermes_discord_allowed_users is defined
       - hermes_discord_allowed_users | length > 0
-    fail_msg: Hermes Discord bot token and allowed users must be provided through secrets.
+      - hermes_parallel_api_key is defined
+      - hermes_parallel_api_key | length > 0
+      - hermes_firecrawl_api_key is defined
+      - hermes_firecrawl_api_key | length > 0
+    fail_msg: Hermes Discord and web backend credentials must be provided through secrets.
   no_log: true
 
 - name: Install Hermes runtime packages
@@ -130,7 +134,7 @@
     group: root
     mode: "0755"
 
-- name: Configure Hermes auxiliary compression route
+- name: Configure Hermes runtime settings
   ansible.builtin.command:
     cmd: "{{ hermes_venv_path }}/bin/python {{ hermes_install_dir }}/configure-runtime.py"
   register: hermes_runtime_config

--- a/infra/ansible/roles/hermes/templates/hermes-configure-runtime.py.j2
+++ b/infra/ansible/roles/hermes/templates/hermes-configure-runtime.py.j2
@@ -9,6 +9,8 @@ import yaml
 
 CONFIG_PATH = Path("{{ hermes_home }}/config.yaml")
 DESIRED_COMPRESSION_PROVIDER = "{{ hermes_auxiliary_compression_provider }}"
+DESIRED_WEB_SEARCH_BACKEND = "{{ hermes_web_search_backend }}"
+DESIRED_WEB_EXTRACT_BACKEND = "{{ hermes_web_extract_backend }}"
 SERVICE_USER = "{{ hermes_user }}"
 SERVICE_GROUP = "{{ hermes_group }}"
 
@@ -35,6 +37,7 @@ def main():
 
     auxiliary = ensure_dict(config, "auxiliary")
     compression = ensure_dict(auxiliary, "compression")
+    web = ensure_dict(config, "web")
 
     changed = False
     if compression.get("provider") != DESIRED_COMPRESSION_PROVIDER:
@@ -42,6 +45,16 @@ def main():
         changed = True
     if compression.get("model") != "":
         compression["model"] = ""
+        changed = True
+
+    if web.get("search_backend") != DESIRED_WEB_SEARCH_BACKEND:
+        web["search_backend"] = DESIRED_WEB_SEARCH_BACKEND
+        changed = True
+    if web.get("extract_backend") != DESIRED_WEB_EXTRACT_BACKEND:
+        web["extract_backend"] = DESIRED_WEB_EXTRACT_BACKEND
+        changed = True
+    if web.get("backend") != "":
+        web["backend"] = ""
         changed = True
 
     if not changed:

--- a/infra/ansible/roles/hermes/templates/hermes-gateway.env.j2
+++ b/infra/ansible/roles/hermes/templates/hermes-gateway.env.j2
@@ -6,3 +6,5 @@ DISCORD_BOT_TOKEN={{ hermes_discord_bot_token | quote }}
 DISCORD_ALLOWED_USERS={{ hermes_discord_allowed_users | quote }}
 DISCORD_REQUIRE_MENTION={{ hermes_discord_require_mention | string | lower | quote }}
 DISCORD_IGNORE_NO_MENTION={{ hermes_discord_ignore_no_mention | string | lower | quote }}
+PARALLEL_API_KEY={{ hermes_parallel_api_key | quote }}
+FIRECRAWL_API_KEY={{ hermes_firecrawl_api_key | quote }}

--- a/scripts/ci/write_ansible_extra_vars.py
+++ b/scripts/ci/write_ansible_extra_vars.py
@@ -20,6 +20,8 @@ REQUIRED_ENV = {
     "qbittorrent_webui_password": "QBITTORRENT_WEBUI_PASSWORD",
     "hermes_discord_bot_token": "HERMES_DISCORD_BOT_TOKEN",
     "hermes_discord_allowed_users": "HERMES_DISCORD_ALLOWED_USERS",
+    "hermes_parallel_api_key": "PARALLEL_API_KEY",
+    "hermes_firecrawl_api_key": "FIRECRAWL_API_KEY",
 }
 
 

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -13,12 +13,16 @@ Expected encrypted values:
 - `qbittorrent_webui_password`
 - `hermes_discord_bot_token`
 - `hermes_discord_allowed_users`
+- `hermes_parallel_api_key`
+- `hermes_firecrawl_api_key`
 - `copyparty_users`, as a list of account objects with `name` and `password`
 - `adguard_admin_password`, as plaintext; the AdGuard role hashes it before writing the service config
 
 Non-secret deployment values:
 
 - `adguard_admin_username`, optional; defaults to `admin`
+
+GitHub Actions secret names for the Hermes web backends are `PARALLEL_API_KEY` and `FIRECRAWL_API_KEY`; the CD helper maps them to `hermes_parallel_api_key` and `hermes_firecrawl_api_key` for Ansible.
 
 Do not commit decrypted secret files.
 

--- a/tests/hermes/test_hermes_edge_and_runbook.py
+++ b/tests/hermes/test_hermes_edge_and_runbook.py
@@ -80,17 +80,21 @@ def test_validate_playbook_checks_hermes_gateway_service_only():
     assert "hermes_webui_port" not in hermes_tasks
 
 
-def test_secrets_readme_documents_hermes_discord_secrets():
+def test_secrets_readme_documents_hermes_discord_and_web_secrets():
     secrets = read("secrets/README.md")
 
     assert "hermes_discord_bot_token" in secrets
     assert "hermes_discord_allowed_users" in secrets
+    assert "hermes_parallel_api_key" in secrets
+    assert "hermes_firecrawl_api_key" in secrets
+    assert "PARALLEL_API_KEY" in secrets
+    assert "FIRECRAWL_API_KEY" in secrets
     assert "hermes_webui_password" not in secrets
     for forbidden_key in ("HERMES_API_KEY", "API_SERVER_KEY", "OPENAI_API_KEY"):
         assert forbidden_key not in secrets
 
 
-def test_hermes_runbook_documents_discord_gateway_and_fresh_lxc_rebuild():
+def test_hermes_runbook_documents_discord_gateway_web_search_and_fresh_lxc_rebuild():
     runbook = read("docs/runbooks/hermes-agent-discord.md")
 
     assert "Hermes Agent Discord gateway" in runbook
@@ -99,8 +103,12 @@ def test_hermes_runbook_documents_discord_gateway_and_fresh_lxc_rebuild():
     assert "infra/ansible/playbooks/validate.yml" in runbook
     assert "HERMES_DISCORD_BOT_TOKEN" in runbook
     assert "HERMES_DISCORD_ALLOWED_USERS" in runbook
+    assert "PARALLEL_API_KEY" in runbook
+    assert "FIRECRAWL_API_KEY" in runbook
+    assert "search_backend: parallel" in runbook
+    assert "extract_backend: firecrawl" in runbook
     assert "rebuild_hermes_lxc" not in runbook
     assert 'module.lxc["hermes"].proxmox_virtual_environment_container.this' not in runbook
     assert "/workspace" in runbook
-    assert "provider/model setup" in runbook
+    assert "provider/model setup" not in runbook
     assert "https://hermes.home.hchu.me" not in runbook

--- a/tests/hermes/test_hermes_infra.py
+++ b/tests/hermes/test_hermes_infra.py
@@ -107,7 +107,7 @@ def test_proxmox_storage_role_creates_hermes_host_directories():
     assert '"${mount_path}/hermes"' in tasks
 
 
-def test_cd_workflow_passes_hermes_discord_secrets_to_ansible_extra_vars():
+def test_cd_workflow_passes_hermes_discord_and_web_secrets_to_ansible_extra_vars():
     workflow = read(".github/workflows/cd.yml")
     writer = read("scripts/ci/write_ansible_extra_vars.py")
 
@@ -117,6 +117,14 @@ def test_cd_workflow_passes_hermes_discord_secrets_to_ansible_extra_vars():
     assert "HERMES_DISCORD_BOT_TOKEN" in writer
     assert "hermes_discord_allowed_users" in writer
     assert "HERMES_DISCORD_ALLOWED_USERS" in writer
+
+    assert "PARALLEL_API_KEY:" in workflow
+    assert "FIRECRAWL_API_KEY:" in workflow
+    assert "hermes_parallel_api_key" in writer
+    assert "PARALLEL_API_KEY" in writer
+    assert "hermes_firecrawl_api_key" in writer
+    assert "FIRECRAWL_API_KEY" in writer
+
     assert "HERMES_WEBUI_PASSWORD:" not in workflow
     assert "HERMES_API_KEY" not in workflow
     assert "API_SERVER_KEY" not in workflow

--- a/tests/hermes/test_hermes_role.py
+++ b/tests/hermes/test_hermes_role.py
@@ -17,11 +17,13 @@ def find_task(tasks, name: str):
     return next(task for task in tasks if task.get("name") == name)
 
 
-def test_hermes_role_installs_native_gateway_without_webui_or_provider_keys():
+def test_hermes_role_installs_native_gateway_without_webui_or_model_provider_keys():
     tasks = read("infra/ansible/roles/hermes/tasks/main.yml")
 
     assert "hermes_discord_bot_token is defined" in tasks
     assert "hermes_discord_allowed_users is defined" in tasks
+    assert "hermes_parallel_api_key is defined" in tasks
+    assert "hermes_firecrawl_api_key is defined" in tasks
     assert "- bash" in tasks
     assert "python3-venv" in tasks
     assert "python3-pip" in tasks
@@ -98,7 +100,7 @@ def test_hermes_role_routes_auxiliary_compression_to_main_provider():
     assert template_task["ansible.builtin.template"]["dest"] == "{{ hermes_install_dir }}/configure-runtime.py"
     assert template_task["ansible.builtin.template"]["mode"] == "0755"
 
-    configure_task = find_task(tasks, "Configure Hermes auxiliary compression route")
+    configure_task = find_task(tasks, "Configure Hermes runtime settings")
     assert configure_task["ansible.builtin.command"]["cmd"] == (
         "{{ hermes_venv_path }}/bin/python "
         "{{ hermes_install_dir }}/configure-runtime.py"
@@ -115,6 +117,23 @@ def test_hermes_role_routes_auxiliary_compression_to_main_provider():
     assert 'compression["model"] = ""' in script
     assert "gpt-5.5" not in script
     assert "api_key" not in script
+
+
+def test_hermes_role_configures_parallel_search_and_firecrawl_extract():
+    tasks = read_yaml("infra/ansible/roles/hermes/tasks/main.yml")
+    group_vars = read_yaml("infra/ansible/inventory/prod/group_vars/svc_hermes.yml")
+    script = read("infra/ansible/roles/hermes/templates/hermes-configure-runtime.py.j2")
+
+    assert group_vars["hermes_web_search_backend"] == "parallel"
+    assert group_vars["hermes_web_extract_backend"] == "firecrawl"
+
+    assert "DESIRED_WEB_SEARCH_BACKEND" in script
+    assert "DESIRED_WEB_EXTRACT_BACKEND" in script
+    assert 'web["search_backend"] = DESIRED_WEB_SEARCH_BACKEND' in script
+    assert 'web["extract_backend"] = DESIRED_WEB_EXTRACT_BACKEND' in script
+
+    configure_task = find_task(tasks, "Configure Hermes runtime settings")
+    assert configure_task["notify"] == "Restart hermes-gateway"
 
 
 def test_hermes_role_requires_persistent_bind_mounts_before_writing_state():
@@ -160,7 +179,7 @@ def test_hermes_role_enables_gateway_service_with_systemd():
     assert systemd["state"] == "started"
 
 
-def test_hermes_env_template_contains_discord_gateway_runtime_settings_only():
+def test_hermes_env_template_contains_discord_gateway_runtime_and_web_credentials():
     env_template = read("infra/ansible/roles/hermes/templates/hermes-gateway.env.j2")
 
     assert "HERMES_HOME={{ hermes_home | quote }}" in env_template
@@ -171,6 +190,8 @@ def test_hermes_env_template_contains_discord_gateway_runtime_settings_only():
     assert "DISCORD_ALLOWED_USERS={{ hermes_discord_allowed_users | quote }}" in env_template
     assert "DISCORD_REQUIRE_MENTION={{ hermes_discord_require_mention | string | lower | quote }}" in env_template
     assert "DISCORD_IGNORE_NO_MENTION={{ hermes_discord_ignore_no_mention | string | lower | quote }}" in env_template
+    assert "PARALLEL_API_KEY={{ hermes_parallel_api_key | quote }}" in env_template
+    assert "FIRECRAWL_API_KEY={{ hermes_firecrawl_api_key | quote }}" in env_template
     assert "HERMES_WEBUI" not in env_template
     assert "API_SERVER_KEY" not in env_template
     assert "OPENAI_API_KEY" not in env_template


### PR DESCRIPTION
## Summary
- configure Hermes runtime web search with `search_backend: parallel` and `extract_backend: firecrawl`
- pass `PARALLEL_API_KEY` and `FIRECRAWL_API_KEY` from GitHub Actions prod secrets into the Hermes gateway environment
- document required web backend secrets and add regression tests for the Hermes role/CD/runbook wiring

## Test Plan
- `python scripts/ci/render_ansible_inventory.py --check`
- `pytest -q`
- `ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/bootstrap.yml --syntax-check`
- `ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/site.yml --syntax-check`
- `ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/validate.yml --syntax-check`
