### PR TITLE
feat: manage Hermes compression threshold

### DIFF
--- a/docs/runbooks/hermes-agent-discord.md
+++ b/docs/runbooks/hermes-agent-discord.md
@@ -30,6 +30,18 @@ web:
 
 That gives Hermes Parallel-backed search results and Firecrawl-backed page extraction/scraping. The runtime config helper preserves the existing model/provider settings while enforcing these web backend settings.
 
+## Context compression
+
+The runtime config helper also enforces Hermes' global context-compression behavior:
+
+```yaml
+compression:
+  threshold: 0.85
+  codex_gpt55_autoraise: false
+```
+
+This keeps the general compaction trigger at 85% and disables the Codex gpt-5.5 route-specific autoraise override, so the deployed gateway follows the tracked repo setting instead of an operator-only live edit.
+
 ## Discord setup
 
 1. Create a Discord application and bot in the Discord Developer Portal.

--- a/infra/ansible/inventory/prod/group_vars/svc_hermes.yml
+++ b/infra/ansible/inventory/prod/group_vars/svc_hermes.yml
@@ -14,6 +14,8 @@ hermes_agent_repo: https://github.com/NousResearch/hermes-agent.git
 hermes_agent_ref: 36ae958473b8530ffb1a395c4944b8cdbcae82fe
 
 hermes_auxiliary_compression_provider: main
+hermes_compression_threshold: 0.85
+hermes_compression_codex_gpt55_autoraise: false
 hermes_web_search_backend: parallel
 hermes_web_extract_backend: firecrawl
 

--- a/infra/ansible/roles/hermes/templates/hermes-configure-runtime.py.j2
+++ b/infra/ansible/roles/hermes/templates/hermes-configure-runtime.py.j2
@@ -9,6 +9,8 @@ import yaml
 
 CONFIG_PATH = Path("{{ hermes_home }}/config.yaml")
 DESIRED_COMPRESSION_PROVIDER = "{{ hermes_auxiliary_compression_provider }}"
+DESIRED_COMPRESSION_THRESHOLD = {{ hermes_compression_threshold | float }}
+DESIRED_CODEX_GPT55_AUTORAISE = {{ (hermes_compression_codex_gpt55_autoraise | bool) | ternary('True', 'False') }}
 DESIRED_WEB_SEARCH_BACKEND = "{{ hermes_web_search_backend }}"
 DESIRED_WEB_EXTRACT_BACKEND = "{{ hermes_web_extract_backend }}"
 SERVICE_USER = "{{ hermes_user }}"
@@ -37,6 +39,7 @@ def main():
 
     auxiliary = ensure_dict(config, "auxiliary")
     compression = ensure_dict(auxiliary, "compression")
+    runtime_compression = ensure_dict(config, "compression")
     web = ensure_dict(config, "web")
 
     changed = False
@@ -45,6 +48,16 @@ def main():
         changed = True
     if compression.get("model") != "":
         compression["model"] = ""
+        changed = True
+
+    if runtime_compression.get("threshold") != DESIRED_COMPRESSION_THRESHOLD:
+        runtime_compression["threshold"] = DESIRED_COMPRESSION_THRESHOLD
+        changed = True
+    if (
+        runtime_compression.get("codex_gpt55_autoraise")
+        != DESIRED_CODEX_GPT55_AUTORAISE
+    ):
+        runtime_compression["codex_gpt55_autoraise"] = DESIRED_CODEX_GPT55_AUTORAISE
         changed = True
 
     if web.get("search_backend") != DESIRED_WEB_SEARCH_BACKEND:

--- a/tests/hermes/test_hermes_edge_and_runbook.py
+++ b/tests/hermes/test_hermes_edge_and_runbook.py
@@ -107,6 +107,8 @@ def test_hermes_runbook_documents_discord_gateway_web_search_and_fresh_lxc_rebui
     assert "FIRECRAWL_API_KEY" in runbook
     assert "search_backend: parallel" in runbook
     assert "extract_backend: firecrawl" in runbook
+    assert "threshold: 0.85" in runbook
+    assert "codex_gpt55_autoraise: false" in runbook
     assert "rebuild_hermes_lxc" not in runbook
     assert 'module.lxc["hermes"].proxmox_virtual_environment_container.this' not in runbook
     assert "/workspace" in runbook

--- a/tests/hermes/test_hermes_role.py
+++ b/tests/hermes/test_hermes_role.py
@@ -136,6 +136,23 @@ def test_hermes_role_configures_parallel_search_and_firecrawl_extract():
     assert configure_task["notify"] == "Restart hermes-gateway"
 
 
+def test_hermes_role_configures_compression_threshold_and_codex_gpt55_autoraise():
+    group_vars = read_yaml("infra/ansible/inventory/prod/group_vars/svc_hermes.yml")
+    script = read("infra/ansible/roles/hermes/templates/hermes-configure-runtime.py.j2")
+
+    assert group_vars["hermes_compression_threshold"] == 0.85
+    assert group_vars["hermes_compression_codex_gpt55_autoraise"] is False
+
+    assert "DESIRED_COMPRESSION_THRESHOLD" in script
+    assert "DESIRED_CODEX_GPT55_AUTORAISE" in script
+    assert 'runtime_compression = ensure_dict(config, "compression")' in script
+    assert 'runtime_compression["threshold"] = DESIRED_COMPRESSION_THRESHOLD' in script
+    assert (
+        'runtime_compression["codex_gpt55_autoraise"] = '
+        'DESIRED_CODEX_GPT55_AUTORAISE'
+    ) in script
+
+
 def test_hermes_role_requires_persistent_bind_mounts_before_writing_state():
     tasks = read_yaml("infra/ansible/roles/hermes/tasks/main.yml")
 


### PR DESCRIPTION
## Summary
- manage Hermes global compression settings through the Ansible runtime config helper
- set `compression.threshold` to `0.85`
- set `compression.codex_gpt55_autoraise` to `false`
- document the tracked compression settings in the Hermes Discord gateway runbook

## Test Plan
- `python scripts/ci/render_ansible_inventory.py --check`
- render `infra/ansible/roles/hermes/templates/hermes-configure-runtime.py.j2` with Ansible and `py_compile` the result
- `pytest -q`
- `ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/bootstrap.yml --syntax-check`
- `ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/site.yml --syntax-check`
- `ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/validate.yml --syntax-check`
