### PR TITLE
feat: add Hermes Browserbase browser automation

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -108,6 +108,8 @@ jobs:
           HERMES_DISCORD_ALLOWED_USERS: ${{ secrets.HERMES_DISCORD_ALLOWED_USERS }}
           PARALLEL_API_KEY: ${{ secrets.PARALLEL_API_KEY }}
           FIRECRAWL_API_KEY: ${{ secrets.FIRECRAWL_API_KEY }}
+          BROWSERBASE_API_KEY: ${{ secrets.BROWSERBASE_API_KEY }}
+          BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
           COPYPARTY_USERS_JSON: ${{ secrets.COPYPARTY_USERS_JSON }}
         run: python3 scripts/ci/write_ansible_extra_vars.py "${ANSIBLE_EXTRA_VARS_PATH}"
 

--- a/docs/runbooks/hermes-agent-discord.md
+++ b/docs/runbooks/hermes-agent-discord.md
@@ -10,13 +10,20 @@ Set these GitHub Actions secrets in the `prod` environment:
 - `HERMES_DISCORD_ALLOWED_USERS`: comma-separated Discord user IDs allowed to use the bot.
 - `PARALLEL_API_KEY`: Parallel API key used by Hermes `web_search`.
 - `FIRECRAWL_API_KEY`: Firecrawl API key used by Hermes `web_extract`.
+- `BROWSERBASE_API_KEY`: Browserbase API key used by Hermes browser automation.
+- `BROWSERBASE_PROJECT_ID`: Browserbase project ID used by Hermes browser automation.
 
-The CD workflow writes them to Ansible as `hermes_discord_bot_token`, `hermes_discord_allowed_users`, `hermes_parallel_api_key`, and `hermes_firecrawl_api_key`. Ansible renders Hermes' expected runtime names into `/etc/hermes-gateway.env`:
+The CD workflow writes them to Ansible as `hermes_discord_bot_token`, `hermes_discord_allowed_users`, `hermes_parallel_api_key`, `hermes_firecrawl_api_key`, `hermes_browserbase_api_key`, and `hermes_browserbase_project_id`. Ansible renders Hermes' expected runtime names into `/etc/hermes-gateway.env`:
 
 - `DISCORD_BOT_TOKEN`
 - `DISCORD_ALLOWED_USERS`
 - `PARALLEL_API_KEY`
 - `FIRECRAWL_API_KEY`
+- `BROWSERBASE_API_KEY`
+- `BROWSERBASE_PROJECT_ID`
+- `BROWSERBASE_PROXIES`
+- `BROWSERBASE_ADVANCED_STEALTH`
+- `HOME` (set to `/var/lib/hermes` for `agent-browser`'s local browser cache)
 
 ## Web search
 
@@ -29,6 +36,22 @@ web:
 ```
 
 That gives Hermes Parallel-backed search results and Firecrawl-backed page extraction/scraping. The runtime config helper preserves the existing model/provider settings while enforcing these web backend settings.
+
+## Browser automation
+
+Hermes browser automation is enabled for the Discord gateway with Browserbase cloud browsing:
+
+```yaml
+browser:
+  cloud_provider: browserbase
+  auto_local_for_private_urls: true
+platform_toolsets:
+  discord:
+    - hermes-discord
+    - browser
+```
+
+The Ansible role installs Node.js/npm and the `agent-browser` package from the pinned Hermes Agent checkout. Browserbase hosts Chromium for public cloud sessions. Because `auto_local_for_private_urls: true` keeps LAN/localhost URLs out of Browserbase, the role also installs a local browser runtime under `/var/lib/hermes/.agent-browser/browsers` with `HOME=/var/lib/hermes` so Hermes' local sidecar can handle private targets.
 
 ## Context compression
 
@@ -54,7 +77,7 @@ With the default repo settings, DMs always receive responses. Server channels re
 
 ## Deploy and validate
 
-1. Confirm the Discord secrets exist in the `prod` environment.
+1. Confirm the Discord, web backend, and Browserbase secrets exist in the `prod` environment.
 2. Run `infra/ansible/playbooks/bootstrap.yml` through CD, or directly if doing a controlled maintenance deploy.
 3. Run `infra/ansible/playbooks/site.yml`.
 4. Run `infra/ansible/playbooks/validate.yml`.

--- a/infra/ansible/inventory/prod/group_vars/svc_hermes.yml
+++ b/infra/ansible/inventory/prod/group_vars/svc_hermes.yml
@@ -18,6 +18,11 @@ hermes_compression_threshold: 0.85
 hermes_compression_codex_gpt55_autoraise: false
 hermes_web_search_backend: parallel
 hermes_web_extract_backend: firecrawl
+hermes_browser_cloud_provider: browserbase
+hermes_browser_auto_local_for_private_urls: true
+hermes_browser_browsers_path: "{{ hermes_home }}/.agent-browser/browsers"
+hermes_browserbase_proxies: true
+hermes_browserbase_advanced_stealth: false
 
 hermes_discord_require_mention: true
 hermes_discord_ignore_no_mention: true

--- a/infra/ansible/playbooks/validate.yml
+++ b/infra/ansible/playbooks/validate.yml
@@ -236,3 +236,14 @@
       ansible.builtin.command:
         cmd: systemctl is-active hermes-gateway
       changed_when: false
+
+    - name: Check Hermes browser automation CLI
+      ansible.builtin.command:
+        cmd: test -x "{{ hermes_agent_dir }}/node_modules/.bin/agent-browser"
+      changed_when: false
+
+    - name: Check Hermes local browser runtime
+      ansible.builtin.command:
+        cmd: >-
+          python3 -c 'import os, sys; p = "{{ hermes_browser_browsers_path }}"; sys.exit(0 if os.path.isdir(p) and any(n.startswith("chrome-") for n in os.listdir(p)) else 1)'
+      changed_when: false

--- a/infra/ansible/roles/hermes/tasks/main.yml
+++ b/infra/ansible/roles/hermes/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Require Hermes Discord gateway and web backend secrets
+- name: Require Hermes Discord gateway, web backend, and browser credentials
   ansible.builtin.assert:
     that:
       - hermes_discord_bot_token is defined
@@ -10,7 +10,11 @@
       - hermes_parallel_api_key | length > 0
       - hermes_firecrawl_api_key is defined
       - hermes_firecrawl_api_key | length > 0
-    fail_msg: Hermes Discord and web backend credentials must be provided through secrets.
+      - hermes_browserbase_api_key is defined
+      - hermes_browserbase_api_key | length > 0
+      - hermes_browserbase_project_id is defined
+      - hermes_browserbase_project_id | length > 0
+    fail_msg: Hermes Discord, web backend, and Browserbase credentials must be provided through secrets.
   no_log: true
 
 - name: Install Hermes runtime packages
@@ -22,6 +26,8 @@
       - curl
       - gh
       - git
+      - nodejs
+      - npm
       - python3
       - python3-pip
       - python3-venv
@@ -95,6 +101,7 @@
     dest: "{{ hermes_agent_dir }}"
     version: "{{ hermes_agent_ref }}"
     update: true
+  register: hermes_agent_checkout
   notify: Restart hermes-gateway
 
 - name: Create Hermes Python virtualenv
@@ -117,6 +124,51 @@
     editable: true
     virtualenv: "{{ hermes_venv_path }}"
   notify: Restart hermes-gateway
+
+- name: Check Hermes browser automation CLI
+  ansible.builtin.stat:
+    path: "{{ hermes_agent_dir }}/node_modules/.bin/agent-browser"
+  register: hermes_agent_browser_cli
+
+- name: Install Hermes browser automation Node dependencies
+  ansible.builtin.command:
+    cmd: npm ci --omit=dev --silent --workspaces=false
+    chdir: "{{ hermes_agent_dir }}"
+  when: hermes_agent_checkout.changed or not hermes_agent_browser_cli.stat.exists
+  notify: Restart hermes-gateway
+
+- name: Create Hermes local browser runtime directory
+  ansible.builtin.file:
+    path: "{{ hermes_browser_browsers_path }}"
+    state: directory
+    owner: "{{ hermes_user }}"
+    group: "{{ hermes_group }}"
+    mode: "0755"
+
+- name: Check Hermes local browser runtime
+  ansible.builtin.find:
+    paths: "{{ hermes_browser_browsers_path }}"
+    patterns:
+      - chrome-*
+    file_type: directory
+  register: hermes_local_browser_builds
+
+- name: Install Hermes local browser runtime for private URL routing
+  ansible.builtin.command:
+    cmd: "{{ hermes_agent_dir }}/node_modules/.bin/agent-browser install --with-deps"
+    chdir: "{{ hermes_agent_dir }}"
+  environment:
+    HOME: "{{ hermes_home }}"
+  when: hermes_browser_auto_local_for_private_urls | bool and (hermes_agent_checkout.changed or not hermes_agent_browser_cli.stat.exists or hermes_local_browser_builds.matched | int == 0)
+  notify: Restart hermes-gateway
+
+- name: Allow Hermes service to manage local browser runtime
+  ansible.builtin.file:
+    path: "{{ hermes_browser_browsers_path }}"
+    state: directory
+    owner: "{{ hermes_user }}"
+    group: "{{ hermes_group }}"
+    recurse: true
 
 - name: Allow Hermes service to manage lazy venv deps
   ansible.builtin.file:

--- a/infra/ansible/roles/hermes/templates/hermes-configure-runtime.py.j2
+++ b/infra/ansible/roles/hermes/templates/hermes-configure-runtime.py.j2
@@ -13,6 +13,9 @@ DESIRED_COMPRESSION_THRESHOLD = {{ hermes_compression_threshold | float }}
 DESIRED_CODEX_GPT55_AUTORAISE = {{ (hermes_compression_codex_gpt55_autoraise | bool) | ternary('True', 'False') }}
 DESIRED_WEB_SEARCH_BACKEND = "{{ hermes_web_search_backend }}"
 DESIRED_WEB_EXTRACT_BACKEND = "{{ hermes_web_extract_backend }}"
+DESIRED_BROWSER_CLOUD_PROVIDER = "{{ hermes_browser_cloud_provider }}"
+DESIRED_BROWSER_AUTO_LOCAL_FOR_PRIVATE_URLS = {{ (hermes_browser_auto_local_for_private_urls | bool) | ternary('True', 'False') }}
+DESIRED_DISCORD_TOOLSETS = ["hermes-discord", "browser"]
 SERVICE_USER = "{{ hermes_user }}"
 SERVICE_GROUP = "{{ hermes_group }}"
 
@@ -22,6 +25,15 @@ def ensure_dict(parent, key):
     if isinstance(current, dict):
         return current
     current = {}
+    parent[key] = current
+    return current
+
+
+def ensure_list(parent, key, default_items):
+    current = parent.get(key)
+    if isinstance(current, list):
+        return current
+    current = list(default_items)
     parent[key] = current
     return current
 
@@ -41,6 +53,8 @@ def main():
     compression = ensure_dict(auxiliary, "compression")
     runtime_compression = ensure_dict(config, "compression")
     web = ensure_dict(config, "web")
+    browser = ensure_dict(config, "browser")
+    platform_toolsets = ensure_dict(config, "platform_toolsets")
 
     changed = False
     if compression.get("provider") != DESIRED_COMPRESSION_PROVIDER:
@@ -69,6 +83,29 @@ def main():
     if web.get("backend") != "":
         web["backend"] = ""
         changed = True
+
+    if browser.get("cloud_provider") != DESIRED_BROWSER_CLOUD_PROVIDER:
+        browser["cloud_provider"] = DESIRED_BROWSER_CLOUD_PROVIDER
+        changed = True
+    if (
+        browser.get("auto_local_for_private_urls")
+        != DESIRED_BROWSER_AUTO_LOCAL_FOR_PRIVATE_URLS
+    ):
+        browser["auto_local_for_private_urls"] = DESIRED_BROWSER_AUTO_LOCAL_FOR_PRIVATE_URLS
+        changed = True
+
+    discord_toolsets_existing = platform_toolsets.get("discord")
+    discord_toolsets = ensure_list(
+        platform_toolsets,
+        "discord",
+        DESIRED_DISCORD_TOOLSETS,
+    )
+    if not isinstance(discord_toolsets_existing, list):
+        changed = True
+    for toolset in DESIRED_DISCORD_TOOLSETS:
+        if toolset not in discord_toolsets:
+            discord_toolsets.append(toolset)
+            changed = True
 
     if not changed:
         print("ok")

--- a/infra/ansible/roles/hermes/templates/hermes-gateway.env.j2
+++ b/infra/ansible/roles/hermes/templates/hermes-gateway.env.j2
@@ -1,5 +1,6 @@
 HERMES_HOME={{ hermes_home | quote }}
 HERMES_CONFIG_PATH={{ (hermes_home + '/config.yaml') | quote }}
+HOME={{ hermes_home | quote }}
 SHELL=/bin/bash
 PYTHONUNBUFFERED=1
 DISCORD_BOT_TOKEN={{ hermes_discord_bot_token | quote }}
@@ -8,3 +9,7 @@ DISCORD_REQUIRE_MENTION={{ hermes_discord_require_mention | string | lower | quo
 DISCORD_IGNORE_NO_MENTION={{ hermes_discord_ignore_no_mention | string | lower | quote }}
 PARALLEL_API_KEY={{ hermes_parallel_api_key | quote }}
 FIRECRAWL_API_KEY={{ hermes_firecrawl_api_key | quote }}
+BROWSERBASE_API_KEY={{ hermes_browserbase_api_key | quote }}
+BROWSERBASE_PROJECT_ID={{ hermes_browserbase_project_id | quote }}
+BROWSERBASE_PROXIES={{ hermes_browserbase_proxies | string | lower | quote }}
+BROWSERBASE_ADVANCED_STEALTH={{ hermes_browserbase_advanced_stealth | string | lower | quote }}

--- a/scripts/ci/write_ansible_extra_vars.py
+++ b/scripts/ci/write_ansible_extra_vars.py
@@ -22,6 +22,8 @@ REQUIRED_ENV = {
     "hermes_discord_allowed_users": "HERMES_DISCORD_ALLOWED_USERS",
     "hermes_parallel_api_key": "PARALLEL_API_KEY",
     "hermes_firecrawl_api_key": "FIRECRAWL_API_KEY",
+    "hermes_browserbase_api_key": "BROWSERBASE_API_KEY",
+    "hermes_browserbase_project_id": "BROWSERBASE_PROJECT_ID",
 }
 
 

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -15,6 +15,8 @@ Expected encrypted values:
 - `hermes_discord_allowed_users`
 - `hermes_parallel_api_key`
 - `hermes_firecrawl_api_key`
+- `hermes_browserbase_api_key`
+- `hermes_browserbase_project_id`
 - `copyparty_users`, as a list of account objects with `name` and `password`
 - `adguard_admin_password`, as plaintext; the AdGuard role hashes it before writing the service config
 
@@ -22,7 +24,7 @@ Non-secret deployment values:
 
 - `adguard_admin_username`, optional; defaults to `admin`
 
-GitHub Actions secret names for the Hermes web backends are `PARALLEL_API_KEY` and `FIRECRAWL_API_KEY`; the CD helper maps them to `hermes_parallel_api_key` and `hermes_firecrawl_api_key` for Ansible.
+GitHub Actions secret names for the Hermes web and browser backends are `PARALLEL_API_KEY`, `FIRECRAWL_API_KEY`, `BROWSERBASE_API_KEY`, and `BROWSERBASE_PROJECT_ID`; the CD helper maps them to `hermes_parallel_api_key`, `hermes_firecrawl_api_key`, `hermes_browserbase_api_key`, and `hermes_browserbase_project_id` for Ansible.
 
 Do not commit decrypted secret files.
 

--- a/tests/hermes/test_hermes_edge_and_runbook.py
+++ b/tests/hermes/test_hermes_edge_and_runbook.py
@@ -49,7 +49,7 @@ def test_site_playbook_applies_hermes_role():
     assert "hermes" in role_names
 
 
-def test_validate_playbook_checks_hermes_gateway_service_only():
+def test_validate_playbook_checks_hermes_gateway_service_and_browser_cli():
     validate = read_yaml("infra/ansible/playbooks/validate.yml")
     edge_play = next(
         (play for play in validate if play.get("name") == "Validate edge"),
@@ -76,25 +76,33 @@ def test_validate_playbook_checks_hermes_gateway_service_only():
     assert hermes_play.get("hosts") == "svc_hermes"
     hermes_tasks = yaml.safe_dump(hermes_play.get("tasks", []), sort_keys=True)
     assert "systemctl is-active hermes-gateway" in hermes_tasks
+    assert "node_modules/.bin/agent-browser" in hermes_tasks
+    assert "hermes_browser_browsers_path" in hermes_tasks
+    assert "chrome-" in hermes_tasks
+    assert "chromium-" not in hermes_tasks
     assert "hermes-webui" not in hermes_tasks
     assert "hermes_webui_port" not in hermes_tasks
 
 
-def test_secrets_readme_documents_hermes_discord_and_web_secrets():
+def test_secrets_readme_documents_hermes_discord_web_and_browser_secrets():
     secrets = read("secrets/README.md")
 
     assert "hermes_discord_bot_token" in secrets
     assert "hermes_discord_allowed_users" in secrets
     assert "hermes_parallel_api_key" in secrets
     assert "hermes_firecrawl_api_key" in secrets
+    assert "hermes_browserbase_api_key" in secrets
+    assert "hermes_browserbase_project_id" in secrets
     assert "PARALLEL_API_KEY" in secrets
     assert "FIRECRAWL_API_KEY" in secrets
+    assert "BROWSERBASE_API_KEY" in secrets
+    assert "BROWSERBASE_PROJECT_ID" in secrets
     assert "hermes_webui_password" not in secrets
     for forbidden_key in ("HERMES_API_KEY", "API_SERVER_KEY", "OPENAI_API_KEY"):
         assert forbidden_key not in secrets
 
 
-def test_hermes_runbook_documents_discord_gateway_web_search_and_fresh_lxc_rebuild():
+def test_hermes_runbook_documents_discord_gateway_web_search_browser_automation_and_fresh_lxc_rebuild():
     runbook = read("docs/runbooks/hermes-agent-discord.md")
 
     assert "Hermes Agent Discord gateway" in runbook
@@ -105,8 +113,16 @@ def test_hermes_runbook_documents_discord_gateway_web_search_and_fresh_lxc_rebui
     assert "HERMES_DISCORD_ALLOWED_USERS" in runbook
     assert "PARALLEL_API_KEY" in runbook
     assert "FIRECRAWL_API_KEY" in runbook
+    assert "BROWSERBASE_API_KEY" in runbook
+    assert "BROWSERBASE_PROJECT_ID" in runbook
     assert "search_backend: parallel" in runbook
     assert "extract_backend: firecrawl" in runbook
+    assert "cloud_provider: browserbase" in runbook
+    assert "auto_local_for_private_urls: true" in runbook
+    assert "agent-browser" in runbook
+    assert "local browser runtime" in runbook
+    assert "/var/lib/hermes/.agent-browser/browsers" in runbook
+    assert "HOME=/var/lib/hermes" in runbook
     assert "threshold: 0.85" in runbook
     assert "codex_gpt55_autoraise: false" in runbook
     assert "rebuild_hermes_lxc" not in runbook

--- a/tests/hermes/test_hermes_infra.py
+++ b/tests/hermes/test_hermes_infra.py
@@ -83,6 +83,8 @@ def test_hermes_group_vars_are_non_secret_service_settings():
     assert "hermes_webui_password:" not in group_vars
     assert "hermes_discord_bot_token:" not in group_vars
     assert "hermes_discord_allowed_users:" not in group_vars
+    assert "hermes_browserbase_api_key:" not in group_vars
+    assert "hermes_browserbase_project_id:" not in group_vars
     assert "hermes_discord_require_mention: true" in group_vars
     assert "hermes_discord_ignore_no_mention: true" in group_vars
     assert "API_SERVER_KEY" not in group_vars
@@ -107,7 +109,7 @@ def test_proxmox_storage_role_creates_hermes_host_directories():
     assert '"${mount_path}/hermes"' in tasks
 
 
-def test_cd_workflow_passes_hermes_discord_and_web_secrets_to_ansible_extra_vars():
+def test_cd_workflow_passes_hermes_discord_web_and_browser_secrets_to_ansible_extra_vars():
     workflow = read(".github/workflows/cd.yml")
     writer = read("scripts/ci/write_ansible_extra_vars.py")
 
@@ -124,6 +126,13 @@ def test_cd_workflow_passes_hermes_discord_and_web_secrets_to_ansible_extra_vars
     assert "PARALLEL_API_KEY" in writer
     assert "hermes_firecrawl_api_key" in writer
     assert "FIRECRAWL_API_KEY" in writer
+
+    assert "BROWSERBASE_API_KEY:" in workflow
+    assert "BROWSERBASE_PROJECT_ID:" in workflow
+    assert "hermes_browserbase_api_key" in writer
+    assert "BROWSERBASE_API_KEY" in writer
+    assert "hermes_browserbase_project_id" in writer
+    assert "BROWSERBASE_PROJECT_ID" in writer
 
     assert "HERMES_WEBUI_PASSWORD:" not in workflow
     assert "HERMES_API_KEY" not in workflow

--- a/tests/hermes/test_hermes_role.py
+++ b/tests/hermes/test_hermes_role.py
@@ -24,7 +24,11 @@ def test_hermes_role_installs_native_gateway_without_webui_or_model_provider_key
     assert "hermes_discord_allowed_users is defined" in tasks
     assert "hermes_parallel_api_key is defined" in tasks
     assert "hermes_firecrawl_api_key is defined" in tasks
+    assert "hermes_browserbase_api_key is defined" in tasks
+    assert "hermes_browserbase_project_id is defined" in tasks
     assert "- bash" in tasks
+    assert "- nodejs" in tasks
+    assert "- npm" in tasks
     assert "python3-venv" in tasks
     assert "python3-pip" in tasks
     assert "build-essential" in tasks
@@ -53,6 +57,87 @@ def test_hermes_role_installs_github_cli_for_workspace_tasks():
 
     package_task = find_task(tasks, "Install Hermes runtime packages")
     assert "gh" in package_task["ansible.builtin.apt"]["name"]
+
+
+def test_hermes_role_installs_agent_browser_node_dependencies():
+    tasks = read_yaml("infra/ansible/roles/hermes/tasks/main.yml")
+
+    package_task = find_task(tasks, "Install Hermes runtime packages")
+    assert "nodejs" in package_task["ansible.builtin.apt"]["name"]
+    assert "npm" in package_task["ansible.builtin.apt"]["name"]
+
+    checkout_task = find_task(tasks, "Clone Hermes Agent")
+    assert checkout_task["register"] == "hermes_agent_checkout"
+
+    stat_task = find_task(tasks, "Check Hermes browser automation CLI")
+    assert stat_task["ansible.builtin.stat"]["path"] == (
+        "{{ hermes_agent_dir }}/node_modules/.bin/agent-browser"
+    )
+    assert stat_task["register"] == "hermes_agent_browser_cli"
+
+    npm_task = find_task(tasks, "Install Hermes browser automation Node dependencies")
+    assert npm_task["ansible.builtin.command"]["cmd"] == (
+        "npm ci --omit=dev --silent --workspaces=false"
+    )
+    assert npm_task["ansible.builtin.command"]["chdir"] == "{{ hermes_agent_dir }}"
+    assert npm_task["when"] == (
+        "hermes_agent_checkout.changed or not hermes_agent_browser_cli.stat.exists"
+    )
+    assert npm_task["notify"] == "Restart hermes-gateway"
+
+    checkout_index = tasks.index(checkout_task)
+    stat_index = tasks.index(stat_task)
+    npm_index = tasks.index(npm_task)
+    service_index = tasks.index(find_task(tasks, "Enable Hermes gateway"))
+    assert checkout_index < stat_index < npm_index < service_index
+
+
+def test_hermes_role_installs_local_browser_runtime_for_private_url_routing():
+    tasks = read_yaml("infra/ansible/roles/hermes/tasks/main.yml")
+    group_vars = read_yaml("infra/ansible/inventory/prod/group_vars/svc_hermes.yml")
+
+    assert group_vars["hermes_browser_browsers_path"] == "{{ hermes_home }}/.agent-browser/browsers"
+
+    directory_task = find_task(tasks, "Create Hermes local browser runtime directory")
+    assert directory_task["ansible.builtin.file"]["path"] == "{{ hermes_browser_browsers_path }}"
+    assert directory_task["ansible.builtin.file"]["state"] == "directory"
+    assert directory_task["ansible.builtin.file"]["owner"] == "{{ hermes_user }}"
+    assert directory_task["ansible.builtin.file"]["group"] == "{{ hermes_group }}"
+
+    find_task_result = find_task(tasks, "Check Hermes local browser runtime")
+    assert find_task_result["ansible.builtin.find"]["paths"] == "{{ hermes_browser_browsers_path }}"
+    assert find_task_result["ansible.builtin.find"]["patterns"] == [
+        "chrome-*",
+    ]
+    assert find_task_result["register"] == "hermes_local_browser_builds"
+
+    install_task = find_task(tasks, "Install Hermes local browser runtime for private URL routing")
+    assert install_task["ansible.builtin.command"]["cmd"] == (
+        "{{ hermes_agent_dir }}/node_modules/.bin/agent-browser install --with-deps"
+    )
+    assert install_task["ansible.builtin.command"]["chdir"] == "{{ hermes_agent_dir }}"
+    assert install_task["environment"] == {"HOME": "{{ hermes_home }}"}
+    assert install_task["when"] == (
+        "hermes_browser_auto_local_for_private_urls | bool and "
+        "(hermes_agent_checkout.changed or "
+        "not hermes_agent_browser_cli.stat.exists or "
+        "hermes_local_browser_builds.matched | int == 0)"
+    )
+    assert install_task["notify"] == "Restart hermes-gateway"
+
+    ownership_task = find_task(tasks, "Allow Hermes service to manage local browser runtime")
+    assert ownership_task["ansible.builtin.file"]["path"] == "{{ hermes_browser_browsers_path }}"
+    assert ownership_task["ansible.builtin.file"]["owner"] == "{{ hermes_user }}"
+    assert ownership_task["ansible.builtin.file"]["group"] == "{{ hermes_group }}"
+    assert ownership_task["ansible.builtin.file"]["recurse"] is True
+
+    npm_index = tasks.index(find_task(tasks, "Install Hermes browser automation Node dependencies"))
+    directory_index = tasks.index(directory_task)
+    find_index = tasks.index(find_task_result)
+    install_index = tasks.index(install_task)
+    ownership_index = tasks.index(ownership_task)
+    service_index = tasks.index(find_task(tasks, "Enable Hermes gateway"))
+    assert npm_index < directory_index < find_index < install_index < ownership_index < service_index
 
 
 def test_hermes_role_uses_bash_for_service_user_terminal():
@@ -136,6 +221,34 @@ def test_hermes_role_configures_parallel_search_and_firecrawl_extract():
     assert configure_task["notify"] == "Restart hermes-gateway"
 
 
+def test_hermes_role_configures_browserbase_browser_automation():
+    tasks = read_yaml("infra/ansible/roles/hermes/tasks/main.yml")
+    group_vars = read_yaml("infra/ansible/inventory/prod/group_vars/svc_hermes.yml")
+    script = read("infra/ansible/roles/hermes/templates/hermes-configure-runtime.py.j2")
+
+    assert group_vars["hermes_browser_cloud_provider"] == "browserbase"
+    assert group_vars["hermes_browser_auto_local_for_private_urls"] is True
+    assert group_vars["hermes_browser_browsers_path"] == "{{ hermes_home }}/.agent-browser/browsers"
+    assert group_vars["hermes_browserbase_proxies"] is True
+    assert group_vars["hermes_browserbase_advanced_stealth"] is False
+
+    assert "DESIRED_BROWSER_CLOUD_PROVIDER" in script
+    assert "DESIRED_BROWSER_AUTO_LOCAL_FOR_PRIVATE_URLS" in script
+    assert 'browser = ensure_dict(config, "browser")' in script
+    assert 'browser["cloud_provider"] = DESIRED_BROWSER_CLOUD_PROVIDER' in script
+    assert (
+        'browser["auto_local_for_private_urls"] = '
+        'DESIRED_BROWSER_AUTO_LOCAL_FOR_PRIVATE_URLS'
+    ) in script
+    assert 'platform_toolsets = ensure_dict(config, "platform_toolsets")' in script
+    assert 'DESIRED_DISCORD_TOOLSETS = ["hermes-discord", "browser"]' in script
+    assert "discord_toolsets = ensure_list" in script
+    assert '"discord"' in script
+
+    configure_task = find_task(tasks, "Configure Hermes runtime settings")
+    assert configure_task["notify"] == "Restart hermes-gateway"
+
+
 def test_hermes_role_configures_compression_threshold_and_codex_gpt55_autoraise():
     group_vars = read_yaml("infra/ansible/inventory/prod/group_vars/svc_hermes.yml")
     script = read("infra/ansible/roles/hermes/templates/hermes-configure-runtime.py.j2")
@@ -196,7 +309,7 @@ def test_hermes_role_enables_gateway_service_with_systemd():
     assert systemd["state"] == "started"
 
 
-def test_hermes_env_template_contains_discord_gateway_runtime_and_web_credentials():
+def test_hermes_env_template_contains_discord_gateway_runtime_web_and_browser_credentials():
     env_template = read("infra/ansible/roles/hermes/templates/hermes-gateway.env.j2")
 
     assert "HERMES_HOME={{ hermes_home | quote }}" in env_template
@@ -209,6 +322,11 @@ def test_hermes_env_template_contains_discord_gateway_runtime_and_web_credential
     assert "DISCORD_IGNORE_NO_MENTION={{ hermes_discord_ignore_no_mention | string | lower | quote }}" in env_template
     assert "PARALLEL_API_KEY={{ hermes_parallel_api_key | quote }}" in env_template
     assert "FIRECRAWL_API_KEY={{ hermes_firecrawl_api_key | quote }}" in env_template
+    assert "BROWSERBASE_API_KEY={{ hermes_browserbase_api_key | quote }}" in env_template
+    assert "BROWSERBASE_PROJECT_ID={{ hermes_browserbase_project_id | quote }}" in env_template
+    assert "BROWSERBASE_PROXIES={{ hermes_browserbase_proxies | string | lower | quote }}" in env_template
+    assert "BROWSERBASE_ADVANCED_STEALTH={{ hermes_browserbase_advanced_stealth | string | lower | quote }}" in env_template
+    assert "HOME={{ hermes_home | quote }}" in env_template
     assert "HERMES_WEBUI" not in env_template
     assert "API_SERVER_KEY" not in env_template
     assert "OPENAI_API_KEY" not in env_template


### PR DESCRIPTION
## Summary
- Enable Hermes Discord gateway browser automation with Browserbase cloud sessions.
- Wire `BROWSERBASE_API_KEY` and `BROWSERBASE_PROJECT_ID` from GitHub Actions secrets into Ansible and `/etc/hermes-gateway.env`.
- Add `browser.cloud_provider: browserbase`, `browser.auto_local_for_private_urls: true`, and Discord `browser` toolset runtime config enforcement.
- Install `agent-browser` from the pinned Hermes Agent checkout and provision a local Chrome runtime under `/var/lib/hermes/.agent-browser/browsers` for LAN/localhost auto-local routing.
- Extend Hermes validation, runbook/secrets docs, and regression tests.

## Test Plan
- `python3 -m venv .venv`
- `. .venv/bin/activate && python -m pip install -r requirements-dev.txt -r requirements-deploy.txt`
- `PYTHONPATH=$PWD python -m pytest tests/hermes/test_hermes_role.py tests/hermes/test_hermes_infra.py tests/hermes/test_hermes_edge_and_runbook.py -q` → 31 passed
- `PYTHONPATH=$PWD python -m pytest -q` → 196 passed
- `PYTHONPATH=$PWD python scripts/ci/render_ansible_inventory.py --check`
- `ANSIBLE_CONFIG=infra/ansible/ansible.cfg ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/bootstrap.yml --syntax-check`
- `ANSIBLE_CONFIG=infra/ansible/ansible.cfg ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/site.yml --syntax-check`
- `ANSIBLE_CONFIG=infra/ansible/ansible.cfg ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/validate.yml --syntax-check`
- `python -m compileall -q scripts tests`
- `git diff --check`
- independent post-fix review: safe to commit

## Deployment notes
- Add `BROWSERBASE_API_KEY` and `BROWSERBASE_PROJECT_ID` to the GitHub Actions `prod` environment before CD deploy.
- First Hermes deploy will download/install the local `agent-browser` Chrome runtime so private URL routing works without sending LAN/localhost targets to Browserbase.