### PR TITLE
fix: allow Hermes local browser sidecar in LXC

### DIFF
--- a/docs/runbooks/hermes-agent-discord.md
+++ b/docs/runbooks/hermes-agent-discord.md
@@ -23,6 +23,7 @@ The CD workflow writes them to Ansible as `hermes_discord_bot_token`, `hermes_di
 - `BROWSERBASE_PROJECT_ID`
 - `BROWSERBASE_PROXIES`
 - `BROWSERBASE_ADVANCED_STEALTH`
+- `AGENT_BROWSER_ARGS` (set to `--no-sandbox,--disable-dev-shm-usage` for the local Chrome sidecar inside the unprivileged LXC)
 - `HOME` (set to `/var/lib/hermes` for `agent-browser`'s local browser cache)
 
 ## Web search

--- a/infra/ansible/inventory/prod/group_vars/svc_hermes.yml
+++ b/infra/ansible/inventory/prod/group_vars/svc_hermes.yml
@@ -21,6 +21,7 @@ hermes_web_extract_backend: firecrawl
 hermes_browser_cloud_provider: browserbase
 hermes_browser_auto_local_for_private_urls: true
 hermes_browser_browsers_path: "{{ hermes_home }}/.agent-browser/browsers"
+hermes_browser_args: --no-sandbox,--disable-dev-shm-usage
 hermes_browserbase_proxies: true
 hermes_browserbase_advanced_stealth: false
 

--- a/infra/ansible/roles/hermes/templates/hermes-gateway.env.j2
+++ b/infra/ansible/roles/hermes/templates/hermes-gateway.env.j2
@@ -13,3 +13,4 @@ BROWSERBASE_API_KEY={{ hermes_browserbase_api_key | quote }}
 BROWSERBASE_PROJECT_ID={{ hermes_browserbase_project_id | quote }}
 BROWSERBASE_PROXIES={{ hermes_browserbase_proxies | string | lower | quote }}
 BROWSERBASE_ADVANCED_STEALTH={{ hermes_browserbase_advanced_stealth | string | lower | quote }}
+AGENT_BROWSER_ARGS={{ hermes_browser_args | quote }}

--- a/tests/hermes/test_hermes_role.py
+++ b/tests/hermes/test_hermes_role.py
@@ -229,6 +229,7 @@ def test_hermes_role_configures_browserbase_browser_automation():
     assert group_vars["hermes_browser_cloud_provider"] == "browserbase"
     assert group_vars["hermes_browser_auto_local_for_private_urls"] is True
     assert group_vars["hermes_browser_browsers_path"] == "{{ hermes_home }}/.agent-browser/browsers"
+    assert group_vars["hermes_browser_args"] == "--no-sandbox,--disable-dev-shm-usage"
     assert group_vars["hermes_browserbase_proxies"] is True
     assert group_vars["hermes_browserbase_advanced_stealth"] is False
 
@@ -326,6 +327,7 @@ def test_hermes_env_template_contains_discord_gateway_runtime_web_and_browser_cr
     assert "BROWSERBASE_PROJECT_ID={{ hermes_browserbase_project_id | quote }}" in env_template
     assert "BROWSERBASE_PROXIES={{ hermes_browserbase_proxies | string | lower | quote }}" in env_template
     assert "BROWSERBASE_ADVANCED_STEALTH={{ hermes_browserbase_advanced_stealth | string | lower | quote }}" in env_template
+    assert "AGENT_BROWSER_ARGS={{ hermes_browser_args | quote }}" in env_template
     assert "HOME={{ hermes_home | quote }}" in env_template
     assert "HERMES_WEBUI" not in env_template
     assert "API_SERVER_KEY" not in env_template


### PR DESCRIPTION
## Summary
- Set `AGENT_BROWSER_ARGS=--no-sandbox,--disable-dev-shm-usage` for the Hermes gateway.
- Keep the local `agent-browser` Chrome cache under `HOME=/var/lib/hermes` for private/LAN auto-local routing.
- Document why the no-sandbox flags are needed in the unprivileged Hermes LXC.
- Add regression coverage for the new env var.

## Why
Browserbase cloud browsing works for public URLs, but deploy smoke testing found private URL auto-local routing failed when local Chrome launched inside the Hermes LXC:

```text
Chrome exited early without writing DevToolsActivePort
FATAL:sandbox/linux/services/credentials.cc:131 Check failed: Permission denied (13)
Hint: try --args "--no-sandbox"
```

A manual smoke test with `HOME=/var/lib/hermes` and `AGENT_BROWSER_ARGS=--no-sandbox,--disable-dev-shm-usage` successfully opened `https://adguard.home.hchu.me/login.html` using the local sidecar.

## Test Plan
- Browserbase public URL smoke: `browser_navigate("https://example.com")` → success, Browserbase/basic stealth response.
- Private URL current deploy smoke: `browser_navigate("https://adguard.home.hchu.me")` → reproduced Chrome sandbox failure.
- Manual fixed-env local sidecar smoke:
  - `HOME=/var/lib/hermes AGENT_BROWSER_ARGS=--no-sandbox,--disable-dev-shm-usage /opt/hermes/hermes-agent/node_modules/.bin/agent-browser --session hermes-smoke --json open https://adguard.home.hchu.me`
  - result: `{"success":true,"data":{"title":"Login","url":"https://adguard.home.hchu.me/login.html"},"error":null}`
- `PYTHONPATH=$PWD python -m pytest tests/hermes/test_hermes_role.py tests/hermes/test_hermes_infra.py tests/hermes/test_hermes_edge_and_runbook.py -q` → 31 passed
- `PYTHONPATH=$PWD python -m pytest -q` → 196 passed
- `PYTHONPATH=$PWD python scripts/ci/render_ansible_inventory.py --check`
- `ANSIBLE_CONFIG=infra/ansible/ansible.cfg ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/bootstrap.yml --syntax-check`
- `ANSIBLE_CONFIG=infra/ansible/ansible.cfg ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/site.yml --syntax-check`
- `ANSIBLE_CONFIG=infra/ansible/ansible.cfg ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/validate.yml --syntax-check`
- `python -m compileall -q scripts tests`
- `git diff --check`
