### PR TITLE
feat: integrate 1Password for Hermes

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -110,6 +110,7 @@ jobs:
           FIRECRAWL_API_KEY: ${{ secrets.FIRECRAWL_API_KEY }}
           BROWSERBASE_API_KEY: ${{ secrets.BROWSERBASE_API_KEY }}
           BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           COPYPARTY_USERS_JSON: ${{ secrets.COPYPARTY_USERS_JSON }}
         run: python3 scripts/ci/write_ansible_extra_vars.py "${ANSIBLE_EXTRA_VARS_PATH}"
 

--- a/docs/runbooks/hermes-agent-discord.md
+++ b/docs/runbooks/hermes-agent-discord.md
@@ -12,8 +12,9 @@ Set these GitHub Actions secrets in the `prod` environment:
 - `FIRECRAWL_API_KEY`: Firecrawl API key used by Hermes `web_extract`.
 - `BROWSERBASE_API_KEY`: Browserbase API key used by Hermes browser automation.
 - `BROWSERBASE_PROJECT_ID`: Browserbase project ID used by Hermes browser automation.
+- `OP_SERVICE_ACCOUNT_TOKEN`: 1Password service account token used by the `op` CLI for non-interactive secret access.
 
-The CD workflow writes them to Ansible as `hermes_discord_bot_token`, `hermes_discord_allowed_users`, `hermes_parallel_api_key`, `hermes_firecrawl_api_key`, `hermes_browserbase_api_key`, and `hermes_browserbase_project_id`. Ansible renders Hermes' expected runtime names into `/etc/hermes-gateway.env`:
+The CD workflow writes them to Ansible as `hermes_discord_bot_token`, `hermes_discord_allowed_users`, `hermes_parallel_api_key`, `hermes_firecrawl_api_key`, `hermes_browserbase_api_key`, `hermes_browserbase_project_id`, and `hermes_1password_service_account_token`. Ansible renders Hermes' expected runtime names into `/etc/hermes-gateway.env`:
 
 - `DISCORD_BOT_TOKEN`
 - `DISCORD_ALLOWED_USERS`
@@ -24,6 +25,7 @@ The CD workflow writes them to Ansible as `hermes_discord_bot_token`, `hermes_di
 - `BROWSERBASE_PROXIES`
 - `BROWSERBASE_ADVANCED_STEALTH`
 - `AGENT_BROWSER_ARGS` (set to `--no-sandbox,--disable-dev-shm-usage` for the local Chrome sidecar inside the unprivileged LXC)
+- `OP_SERVICE_ACCOUNT_TOKEN`
 - `HOME` (set to `/var/lib/hermes` for `agent-browser`'s local browser cache)
 
 ## Web search
@@ -54,6 +56,19 @@ platform_toolsets:
 
 The Ansible role installs Node.js/npm and the `agent-browser` package from the pinned Hermes Agent checkout. Browserbase hosts Chromium for public cloud sessions. Because `auto_local_for_private_urls: true` keeps LAN/localhost URLs out of Browserbase, the role also installs a local browser runtime under `/var/lib/hermes/.agent-browser/browsers` with `HOME=/var/lib/hermes` so Hermes' local sidecar can handle private targets.
 
+## 1Password secrets
+
+Hermes can use 1Password-managed secrets from Discord through its terminal tools. The Ansible role installs the official 1Password CLI (`op`) from the 1Password Debian apt repository, installs the Hermes optional skill `official/security/1password` into `/var/lib/hermes/skills/security/1password`, and exposes `OP_SERVICE_ACCOUNT_TOKEN` to the gateway service. Use the service-account flow rather than desktop-app sign-in for the headless LXC.
+
+Examples Hermes can run after deploy:
+
+```bash
+op read "op://Vault/Item/field"
+op run -- env | grep '^EXAMPLE_'
+```
+
+Do not ask Hermes to print raw secret values unless you explicitly need to reveal one; prefer `op run` and `op inject` for commands and templates. Scope the 1Password service account narrowly to the vaults/items Hermes is allowed to read, because allowed Discord users can ask Hermes to run terminal commands that use this token.
+
 ## Context compression
 
 The runtime config helper also enforces Hermes' global context-compression behavior:
@@ -78,7 +93,7 @@ With the default repo settings, DMs always receive responses. Server channels re
 
 ## Deploy and validate
 
-1. Confirm the Discord, web backend, and Browserbase secrets exist in the `prod` environment.
+1. Confirm the Discord, web backend, Browserbase, and 1Password secrets exist in the `prod` environment.
 2. Run `infra/ansible/playbooks/bootstrap.yml` through CD, or directly if doing a controlled maintenance deploy.
 3. Run `infra/ansible/playbooks/site.yml`.
 4. Run `infra/ansible/playbooks/validate.yml`.

--- a/infra/ansible/playbooks/validate.yml
+++ b/infra/ansible/playbooks/validate.yml
@@ -247,3 +247,25 @@
         cmd: >-
           python3 -c 'import os, sys; p = "{{ hermes_browser_browsers_path }}"; sys.exit(0 if os.path.isdir(p) and any(n.startswith("chrome-") for n in os.listdir(p)) else 1)'
       changed_when: false
+
+    - name: Check Hermes 1Password CLI
+      ansible.builtin.command:
+        cmd: op --version
+      changed_when: false
+
+    - name: Check Hermes 1Password skill
+      ansible.builtin.command:
+        cmd: test -f "{{ hermes_home }}/skills/security/1password/SKILL.md"
+      changed_when: false
+
+    - name: Check Hermes 1Password service account authentication
+      ansible.builtin.shell: |
+        set -euo pipefail
+        set -a
+        . "{{ hermes_env_path }}"
+        set +a
+        op whoami >/dev/null
+      args:
+        executable: /bin/bash
+      changed_when: false
+      no_log: true

--- a/infra/ansible/roles/hermes/tasks/main.yml
+++ b/infra/ansible/roles/hermes/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Require Hermes Discord gateway, web backend, and browser credentials
+- name: Require Hermes Discord gateway, web backend, browser, and 1Password credentials
   ansible.builtin.assert:
     that:
       - hermes_discord_bot_token is defined
@@ -14,7 +14,9 @@
       - hermes_browserbase_api_key | length > 0
       - hermes_browserbase_project_id is defined
       - hermes_browserbase_project_id | length > 0
-    fail_msg: Hermes Discord, web backend, and Browserbase credentials must be provided through secrets.
+      - hermes_1password_service_account_token is defined
+      - hermes_1password_service_account_token | length > 0
+    fail_msg: Hermes Discord, web backend, Browserbase, and 1Password credentials must be provided through secrets.
   no_log: true
 
 - name: Install Hermes runtime packages
@@ -31,6 +33,29 @@
       - python3
       - python3-pip
       - python3-venv
+    update_cache: true
+    state: present
+
+- name: Download 1Password apt signing key
+  ansible.builtin.get_url:
+    url: https://downloads.1password.com/linux/keys/1password.asc
+    dest: /usr/share/keyrings/1password-archive-keyring.asc
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Configure 1Password apt repository
+  ansible.builtin.copy:
+    dest: /etc/apt/sources.list.d/1password.list
+    owner: root
+    group: root
+    mode: "0644"
+    content: |
+      deb [arch=amd64 signed-by=/usr/share/keyrings/1password-archive-keyring.asc] https://downloads.1password.com/linux/debian/amd64 stable main
+
+- name: Install 1Password CLI
+  ansible.builtin.apt:
+    name: 1password-cli
     update_cache: true
     state: present
 
@@ -124,6 +149,28 @@
     editable: true
     virtualenv: "{{ hermes_venv_path }}"
   notify: Restart hermes-gateway
+
+- name: Check Hermes 1Password skill
+  ansible.builtin.stat:
+    path: "{{ hermes_home }}/skills/security/1password/SKILL.md"
+  register: hermes_1password_skill
+
+- name: Install Hermes 1Password skill
+  ansible.builtin.command:
+    cmd: "{{ hermes_venv_path }}/bin/hermes skills install official/security/1password --yes"
+  environment:
+    HERMES_HOME: "{{ hermes_home }}"
+    HOME: "{{ hermes_home }}"
+  when: not hermes_1password_skill.stat.exists
+  notify: Restart hermes-gateway
+
+- name: Allow Hermes service to manage skills
+  ansible.builtin.file:
+    path: "{{ hermes_home }}/skills"
+    state: directory
+    owner: "{{ hermes_user }}"
+    group: "{{ hermes_group }}"
+    recurse: true
 
 - name: Check Hermes browser automation CLI
   ansible.builtin.stat:

--- a/infra/ansible/roles/hermes/templates/hermes-gateway.env.j2
+++ b/infra/ansible/roles/hermes/templates/hermes-gateway.env.j2
@@ -14,3 +14,4 @@ BROWSERBASE_PROJECT_ID={{ hermes_browserbase_project_id | quote }}
 BROWSERBASE_PROXIES={{ hermes_browserbase_proxies | string | lower | quote }}
 BROWSERBASE_ADVANCED_STEALTH={{ hermes_browserbase_advanced_stealth | string | lower | quote }}
 AGENT_BROWSER_ARGS={{ hermes_browser_args | quote }}
+OP_SERVICE_ACCOUNT_TOKEN={{ hermes_1password_service_account_token | quote }}

--- a/scripts/ci/write_ansible_extra_vars.py
+++ b/scripts/ci/write_ansible_extra_vars.py
@@ -24,6 +24,7 @@ REQUIRED_ENV = {
     "hermes_firecrawl_api_key": "FIRECRAWL_API_KEY",
     "hermes_browserbase_api_key": "BROWSERBASE_API_KEY",
     "hermes_browserbase_project_id": "BROWSERBASE_PROJECT_ID",
+    "hermes_1password_service_account_token": "OP_SERVICE_ACCOUNT_TOKEN",
 }
 
 

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -17,6 +17,7 @@ Expected encrypted values:
 - `hermes_firecrawl_api_key`
 - `hermes_browserbase_api_key`
 - `hermes_browserbase_project_id`
+- `hermes_1password_service_account_token`
 - `copyparty_users`, as a list of account objects with `name` and `password`
 - `adguard_admin_password`, as plaintext; the AdGuard role hashes it before writing the service config
 
@@ -24,7 +25,7 @@ Non-secret deployment values:
 
 - `adguard_admin_username`, optional; defaults to `admin`
 
-GitHub Actions secret names for the Hermes web and browser backends are `PARALLEL_API_KEY`, `FIRECRAWL_API_KEY`, `BROWSERBASE_API_KEY`, and `BROWSERBASE_PROJECT_ID`; the CD helper maps them to `hermes_parallel_api_key`, `hermes_firecrawl_api_key`, `hermes_browserbase_api_key`, and `hermes_browserbase_project_id` for Ansible.
+GitHub Actions secret names for the Hermes web, browser, and 1Password backends are `PARALLEL_API_KEY`, `FIRECRAWL_API_KEY`, `BROWSERBASE_API_KEY`, `BROWSERBASE_PROJECT_ID`, and `OP_SERVICE_ACCOUNT_TOKEN`; the CD helper maps them to `hermes_parallel_api_key`, `hermes_firecrawl_api_key`, `hermes_browserbase_api_key`, `hermes_browserbase_project_id`, and `hermes_1password_service_account_token` for Ansible.
 
 Do not commit decrypted secret files.
 

--- a/tests/hermes/test_hermes_edge_and_runbook.py
+++ b/tests/hermes/test_hermes_edge_and_runbook.py
@@ -79,12 +79,15 @@ def test_validate_playbook_checks_hermes_gateway_service_and_browser_cli():
     assert "node_modules/.bin/agent-browser" in hermes_tasks
     assert "hermes_browser_browsers_path" in hermes_tasks
     assert "chrome-" in hermes_tasks
+    assert "op --version" in hermes_tasks
+    assert "skills/security/1password/SKILL.md" in hermes_tasks
+    assert "op whoami" in hermes_tasks
     assert "chromium-" not in hermes_tasks
     assert "hermes-webui" not in hermes_tasks
     assert "hermes_webui_port" not in hermes_tasks
 
 
-def test_secrets_readme_documents_hermes_discord_web_and_browser_secrets():
+def test_secrets_readme_documents_hermes_discord_web_browser_and_1password_secrets():
     secrets = read("secrets/README.md")
 
     assert "hermes_discord_bot_token" in secrets
@@ -93,16 +96,18 @@ def test_secrets_readme_documents_hermes_discord_web_and_browser_secrets():
     assert "hermes_firecrawl_api_key" in secrets
     assert "hermes_browserbase_api_key" in secrets
     assert "hermes_browserbase_project_id" in secrets
+    assert "hermes_1password_service_account_token" in secrets
     assert "PARALLEL_API_KEY" in secrets
     assert "FIRECRAWL_API_KEY" in secrets
     assert "BROWSERBASE_API_KEY" in secrets
     assert "BROWSERBASE_PROJECT_ID" in secrets
+    assert "OP_SERVICE_ACCOUNT_TOKEN" in secrets
     assert "hermes_webui_password" not in secrets
     for forbidden_key in ("HERMES_API_KEY", "API_SERVER_KEY", "OPENAI_API_KEY"):
         assert forbidden_key not in secrets
 
 
-def test_hermes_runbook_documents_discord_gateway_web_search_browser_automation_and_fresh_lxc_rebuild():
+def test_hermes_runbook_documents_discord_gateway_web_search_browser_automation_1password_and_fresh_lxc_rebuild():
     runbook = read("docs/runbooks/hermes-agent-discord.md")
 
     assert "Hermes Agent Discord gateway" in runbook
@@ -115,6 +120,7 @@ def test_hermes_runbook_documents_discord_gateway_web_search_browser_automation_
     assert "FIRECRAWL_API_KEY" in runbook
     assert "BROWSERBASE_API_KEY" in runbook
     assert "BROWSERBASE_PROJECT_ID" in runbook
+    assert "OP_SERVICE_ACCOUNT_TOKEN" in runbook
     assert "search_backend: parallel" in runbook
     assert "extract_backend: firecrawl" in runbook
     assert "cloud_provider: browserbase" in runbook
@@ -123,6 +129,10 @@ def test_hermes_runbook_documents_discord_gateway_web_search_browser_automation_
     assert "local browser runtime" in runbook
     assert "/var/lib/hermes/.agent-browser/browsers" in runbook
     assert "HOME=/var/lib/hermes" in runbook
+    assert "1Password" in runbook
+    assert "official/security/1password" in runbook
+    assert "op read" in runbook
+    assert "op run" in runbook
     assert "threshold: 0.85" in runbook
     assert "codex_gpt55_autoraise: false" in runbook
     assert "rebuild_hermes_lxc" not in runbook

--- a/tests/hermes/test_hermes_infra.py
+++ b/tests/hermes/test_hermes_infra.py
@@ -109,7 +109,7 @@ def test_proxmox_storage_role_creates_hermes_host_directories():
     assert '"${mount_path}/hermes"' in tasks
 
 
-def test_cd_workflow_passes_hermes_discord_web_and_browser_secrets_to_ansible_extra_vars():
+def test_cd_workflow_passes_hermes_discord_web_browser_and_1password_secrets_to_ansible_extra_vars():
     workflow = read(".github/workflows/cd.yml")
     writer = read("scripts/ci/write_ansible_extra_vars.py")
 
@@ -133,6 +133,10 @@ def test_cd_workflow_passes_hermes_discord_web_and_browser_secrets_to_ansible_ex
     assert "BROWSERBASE_API_KEY" in writer
     assert "hermes_browserbase_project_id" in writer
     assert "BROWSERBASE_PROJECT_ID" in writer
+
+    assert "OP_SERVICE_ACCOUNT_TOKEN:" in workflow
+    assert "hermes_1password_service_account_token" in writer
+    assert "OP_SERVICE_ACCOUNT_TOKEN" in writer
 
     assert "HERMES_WEBUI_PASSWORD:" not in workflow
     assert "HERMES_API_KEY" not in workflow

--- a/tests/hermes/test_hermes_role.py
+++ b/tests/hermes/test_hermes_role.py
@@ -26,6 +26,7 @@ def test_hermes_role_installs_native_gateway_without_webui_or_model_provider_key
     assert "hermes_firecrawl_api_key is defined" in tasks
     assert "hermes_browserbase_api_key is defined" in tasks
     assert "hermes_browserbase_project_id is defined" in tasks
+    assert "hermes_1password_service_account_token is defined" in tasks
     assert "- bash" in tasks
     assert "- nodejs" in tasks
     assert "- npm" in tasks
@@ -57,6 +58,61 @@ def test_hermes_role_installs_github_cli_for_workspace_tasks():
 
     package_task = find_task(tasks, "Install Hermes runtime packages")
     assert "gh" in package_task["ansible.builtin.apt"]["name"]
+
+
+def test_hermes_role_installs_1password_cli_and_skill_for_secret_access():
+    tasks = read_yaml("infra/ansible/roles/hermes/tasks/main.yml")
+
+    key_task = find_task(tasks, "Download 1Password apt signing key")
+    assert key_task["ansible.builtin.get_url"]["url"] == (
+        "https://downloads.1password.com/linux/keys/1password.asc"
+    )
+    assert key_task["ansible.builtin.get_url"]["dest"] == (
+        "/usr/share/keyrings/1password-archive-keyring.asc"
+    )
+
+    repo_task = find_task(tasks, "Configure 1Password apt repository")
+    assert "downloads.1password.com/linux/debian/amd64" in repo_task["ansible.builtin.copy"]["content"]
+    assert repo_task["ansible.builtin.copy"]["dest"] == "/etc/apt/sources.list.d/1password.list"
+
+    op_task = find_task(tasks, "Install 1Password CLI")
+    assert op_task["ansible.builtin.apt"]["name"] == "1password-cli"
+    assert op_task["ansible.builtin.apt"]["update_cache"] is True
+
+    skill_check_task = find_task(tasks, "Check Hermes 1Password skill")
+    assert skill_check_task["ansible.builtin.stat"]["path"] == (
+        "{{ hermes_home }}/skills/security/1password/SKILL.md"
+    )
+    assert skill_check_task["register"] == "hermes_1password_skill"
+
+    skill_task = find_task(tasks, "Install Hermes 1Password skill")
+    assert skill_task["ansible.builtin.command"]["cmd"] == (
+        "{{ hermes_venv_path }}/bin/hermes skills install official/security/1password --yes"
+    )
+    assert skill_task["environment"] == {
+        "HERMES_HOME": "{{ hermes_home }}",
+        "HOME": "{{ hermes_home }}",
+    }
+    assert skill_task["when"] == "not hermes_1password_skill.stat.exists"
+    assert skill_task["notify"] == "Restart hermes-gateway"
+
+    ownership_task = find_task(tasks, "Allow Hermes service to manage skills")
+    assert ownership_task["ansible.builtin.file"]["path"] == "{{ hermes_home }}/skills"
+    assert ownership_task["ansible.builtin.file"]["owner"] == "{{ hermes_user }}"
+    assert ownership_task["ansible.builtin.file"]["group"] == "{{ hermes_group }}"
+    assert ownership_task["ansible.builtin.file"]["recurse"] is True
+
+    runtime_package_index = tasks.index(find_task(tasks, "Install Hermes runtime packages"))
+    key_index = tasks.index(key_task)
+    repo_index = tasks.index(repo_task)
+    op_index = tasks.index(op_task)
+    agent_pip_index = tasks.index(find_task(tasks, "Install Hermes Agent messaging extras into virtualenv"))
+    skill_check_index = tasks.index(skill_check_task)
+    skill_index = tasks.index(skill_task)
+    ownership_index = tasks.index(ownership_task)
+    service_index = tasks.index(find_task(tasks, "Enable Hermes gateway"))
+    assert runtime_package_index < key_index < repo_index < op_index
+    assert agent_pip_index < skill_check_index < skill_index < ownership_index < service_index
 
 
 def test_hermes_role_installs_agent_browser_node_dependencies():
@@ -328,6 +384,7 @@ def test_hermes_env_template_contains_discord_gateway_runtime_web_and_browser_cr
     assert "BROWSERBASE_PROXIES={{ hermes_browserbase_proxies | string | lower | quote }}" in env_template
     assert "BROWSERBASE_ADVANCED_STEALTH={{ hermes_browserbase_advanced_stealth | string | lower | quote }}" in env_template
     assert "AGENT_BROWSER_ARGS={{ hermes_browser_args | quote }}" in env_template
+    assert "OP_SERVICE_ACCOUNT_TOKEN={{ hermes_1password_service_account_token | quote }}" in env_template
     assert "HOME={{ hermes_home | quote }}" in env_template
     assert "HERMES_WEBUI" not in env_template
     assert "API_SERVER_KEY" not in env_template


### PR DESCRIPTION
## Summary
- Wire `OP_SERVICE_ACCOUNT_TOKEN` from GitHub Actions `prod` secrets into Ansible and `/etc/hermes-gateway.env` for the Hermes gateway.
- Install the official 1Password CLI (`op`) from the 1Password Debian apt repository in the Hermes LXC.
- Install the Hermes optional skill `official/security/1password` into `/var/lib/hermes/skills/security/1password` so Hermes knows how to use `op read`, `op inject`, and `op run`.
- Add validate checks for `op --version`, the installed 1Password skill, and service-account auth via `op whoami` using the rendered gateway env.
- Document deployment requirements, service-account scoping, and regression coverage.

## Security notes
- `OP_SERVICE_ACCOUNT_TOKEN` is intentionally exposed to the Hermes gateway process so terminal subprocesses can use 1Password non-interactively.
- The 1Password service account should be scoped narrowly to only the vaults/items Hermes is allowed to read.
- Prefer `op run` / `op inject`; avoid printing raw secret values unless explicitly needed.

## Test Plan
- Wrote failing tests first for the 1Password CD secret mapping, Ansible role tasks, gateway env, validate playbook, and docs.
- Targeted RED tests failed as expected before implementation.
- `PYTHONPATH=$PWD python -m pytest tests/hermes/test_hermes_role.py tests/hermes/test_hermes_infra.py tests/hermes/test_hermes_edge_and_runbook.py -q` → 32 passed
- `PYTHONPATH=$PWD python -m pytest -q` → 197 passed
- `PYTHONPATH=$PWD python scripts/ci/render_ansible_inventory.py --check`
- `ANSIBLE_CONFIG=infra/ansible/ansible.cfg ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/bootstrap.yml --syntax-check`
- `ANSIBLE_CONFIG=infra/ansible/ansible.cfg ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/site.yml --syntax-check`
- `ANSIBLE_CONFIG=infra/ansible/ansible.cfg ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/validate.yml --syntax-check`
- `python -m compileall -q scripts tests`
- `git diff --check`
- Extra-vars mapping smoke test confirmed `OP_SERVICE_ACCOUNT_TOKEN` maps to `hermes_1password_service_account_token`.
- 1Password apt key and Debian amd64 repo URLs returned HTTP 200.
- Independent pre-commit review found no code-level blockers and marked the diff safe to commit.

## Deployment notes
- Add `OP_SERVICE_ACCOUNT_TOKEN` to the GitHub Actions `prod` environment before CD deploy.
- If the token is missing or invalid, CD/validate will fail intentionally.
