### PR TITLE
fix: keep Hermes 1Password CLI state service-owned

### DIFF
--- a/docs/runbooks/hermes-agent-discord.md
+++ b/docs/runbooks/hermes-agent-discord.md
@@ -67,7 +67,7 @@ op read "op://Vault/Item/field"
 op run -- env | grep '^EXAMPLE_'
 ```
 
-Do not ask Hermes to print raw secret values unless you explicitly need to reveal one; prefer `op run` and `op inject` for commands and templates. Scope the 1Password service account narrowly to the vaults/items Hermes is allowed to read, because allowed Discord users can ask Hermes to run terminal commands that use this token.
+Do not ask Hermes to print raw secret values unless you explicitly need to reveal one; prefer `op run` and `op inject` for commands and templates. Scope the 1Password service account narrowly to the vaults/items Hermes is allowed to read, because allowed Discord users can ask Hermes to run terminal commands that use this token. The role keeps `/var/lib/hermes/.config/op` owned by the `hermes` service user so validation and service commands do not leave root-owned 1Password CLI state behind.
 
 ## Context compression
 

--- a/infra/ansible/playbooks/validate.yml
+++ b/infra/ansible/playbooks/validate.yml
@@ -264,7 +264,7 @@
         set -a
         . "{{ hermes_env_path }}"
         set +a
-        op whoami >/dev/null
+        runuser -u "{{ hermes_user }}" -- env "HOME={{ hermes_home }}" "OP_SERVICE_ACCOUNT_TOKEN=$OP_SERVICE_ACCOUNT_TOKEN" op whoami >/dev/null
       args:
         executable: /bin/bash
       changed_when: false

--- a/infra/ansible/roles/hermes/tasks/main.yml
+++ b/infra/ansible/roles/hermes/tasks/main.yml
@@ -172,6 +172,15 @@
     group: "{{ hermes_group }}"
     recurse: true
 
+- name: Allow Hermes service to manage 1Password CLI config
+  ansible.builtin.file:
+    path: "{{ hermes_home }}/.config/op"
+    state: directory
+    owner: "{{ hermes_user }}"
+    group: "{{ hermes_group }}"
+    mode: "0700"
+    recurse: true
+
 - name: Check Hermes browser automation CLI
   ansible.builtin.stat:
     path: "{{ hermes_agent_dir }}/node_modules/.bin/agent-browser"

--- a/tests/hermes/test_hermes_edge_and_runbook.py
+++ b/tests/hermes/test_hermes_edge_and_runbook.py
@@ -82,6 +82,8 @@ def test_validate_playbook_checks_hermes_gateway_service_and_browser_cli():
     assert "op --version" in hermes_tasks
     assert "skills/security/1password/SKILL.md" in hermes_tasks
     assert "op whoami" in hermes_tasks
+    assert "runuser -u" in hermes_tasks
+    assert "OP_SERVICE_ACCOUNT_TOKEN" in hermes_tasks
     assert "chromium-" not in hermes_tasks
     assert "hermes-webui" not in hermes_tasks
     assert "hermes_webui_port" not in hermes_tasks
@@ -133,6 +135,7 @@ def test_hermes_runbook_documents_discord_gateway_web_search_browser_automation_
     assert "official/security/1password" in runbook
     assert "op read" in runbook
     assert "op run" in runbook
+    assert ".config/op" in runbook
     assert "threshold: 0.85" in runbook
     assert "codex_gpt55_autoraise: false" in runbook
     assert "rebuild_hermes_lxc" not in runbook

--- a/tests/hermes/test_hermes_role.py
+++ b/tests/hermes/test_hermes_role.py
@@ -102,6 +102,14 @@ def test_hermes_role_installs_1password_cli_and_skill_for_secret_access():
     assert ownership_task["ansible.builtin.file"]["group"] == "{{ hermes_group }}"
     assert ownership_task["ansible.builtin.file"]["recurse"] is True
 
+    op_config_task = find_task(tasks, "Allow Hermes service to manage 1Password CLI config")
+    assert op_config_task["ansible.builtin.file"]["path"] == "{{ hermes_home }}/.config/op"
+    assert op_config_task["ansible.builtin.file"]["state"] == "directory"
+    assert op_config_task["ansible.builtin.file"]["owner"] == "{{ hermes_user }}"
+    assert op_config_task["ansible.builtin.file"]["group"] == "{{ hermes_group }}"
+    assert op_config_task["ansible.builtin.file"]["mode"] == "0700"
+    assert op_config_task["ansible.builtin.file"]["recurse"] is True
+
     runtime_package_index = tasks.index(find_task(tasks, "Install Hermes runtime packages"))
     key_index = tasks.index(key_task)
     repo_index = tasks.index(repo_task)
@@ -110,9 +118,10 @@ def test_hermes_role_installs_1password_cli_and_skill_for_secret_access():
     skill_check_index = tasks.index(skill_check_task)
     skill_index = tasks.index(skill_task)
     ownership_index = tasks.index(ownership_task)
+    op_config_index = tasks.index(op_config_task)
     service_index = tasks.index(find_task(tasks, "Enable Hermes gateway"))
     assert runtime_package_index < key_index < repo_index < op_index
-    assert agent_pip_index < skill_check_index < skill_index < ownership_index < service_index
+    assert agent_pip_index < skill_check_index < skill_index < ownership_index < op_config_index < service_index
 
 
 def test_hermes_role_installs_agent_browser_node_dependencies():


### PR DESCRIPTION
## Summary
- Fix post-deploy 1Password smoke failure caused by root-owned `/var/lib/hermes/.config/op`.
- Ensure the Hermes role creates/chowns `/var/lib/hermes/.config/op` as the `hermes` service user.
- Update validation to run `op whoami` as the `hermes` user while root reads the protected env file and passes only the service account token to the subprocess.
- Document the ownership guard and add regression tests.

## What failed after #85 deploy
Gateway-side smoke testing showed:

```text
op_path=/usr/bin/op
op_version=2.34.1
skill_file=present
env_token_present=yes
op whoami: Can't continue. We can't safely access "/var/lib/hermes/.config/op" because it's not owned by the current user.
```

`/var/lib/hermes/.config/op` was owned by `root:root`, so terminal commands running as the `hermes` service user could not use `op` even though the CLI, skill, and token were present.

## Test Plan
- Reproduced live post-deploy failure with `op whoami` as `hermes`.
- Wrote failing regression tests first for the Ansible ownership task, validation command running through `runuser -u {{ hermes_user }}`, and runbook note.
- Targeted RED tests failed before implementation and passed after the fix.
- `PYTHONPATH=$PWD python -m pytest tests/hermes/test_hermes_role.py tests/hermes/test_hermes_infra.py tests/hermes/test_hermes_edge_and_runbook.py -q` → 32 passed
- `PYTHONPATH=$PWD python -m pytest -q` → 197 passed
- `PYTHONPATH=$PWD python scripts/ci/render_ansible_inventory.py --check`
- `ANSIBLE_CONFIG=infra/ansible/ansible.cfg ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/bootstrap.yml --syntax-check`
- `ANSIBLE_CONFIG=infra/ansible/ansible.cfg ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/site.yml --syntax-check`
- `ANSIBLE_CONFIG=infra/ansible/ansible.cfg ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/validate.yml --syntax-check`
- `python -m compileall -q scripts tests`
- `git diff --check`
- static scan findings: none
