### PR TITLE
fix: route Hermes compression off Codex

### DIFF
--- a/docs/runbooks/hermes-agent-discord.md
+++ b/docs/runbooks/hermes-agent-discord.md
@@ -71,15 +71,20 @@ Do not ask Hermes to print raw secret values unless you explicitly need to revea
 
 ## Context compression
 
-The runtime config helper also enforces Hermes' global context-compression behavior:
+The runtime config helper also enforces Hermes' global context-compression behavior and routes compression summaries away from the main Codex `gpt-5.5` Responses path:
 
 ```yaml
 compression:
   threshold: 0.85
   codex_gpt55_autoraise: false
+auxiliary:
+  compression:
+    provider: copilot
+    model: gpt-4o-mini
+    timeout: 90
 ```
 
-This keeps the general compaction trigger at 85% and disables the Codex gpt-5.5 route-specific autoraise override, so the deployed gateway follows the tracked repo setting instead of an operator-only live edit.
+This keeps the general compaction trigger at 85% and disables the Codex gpt-5.5 route-specific autoraise override, so the deployed gateway follows the tracked repo setting instead of an operator-only live edit. Compression summaries use Copilot `gpt-4o-mini` because the Codex auxiliary Responses stream has repeatedly exceeded the 120s total timeout with `Codex auxiliary Responses stream exceeded 120.0s`, causing Hermes to insert fallback context markers instead of durable summaries. Keep a working Copilot credential in `/var/lib/hermes/auth.json`; the validate playbook asserts the configured compression route after deploy.
 
 ## Discord setup
 

--- a/infra/ansible/inventory/prod/group_vars/svc_hermes.yml
+++ b/infra/ansible/inventory/prod/group_vars/svc_hermes.yml
@@ -13,7 +13,9 @@ hermes_env_path: /etc/hermes-gateway.env
 hermes_agent_repo: https://github.com/NousResearch/hermes-agent.git
 hermes_agent_ref: 36ae958473b8530ffb1a395c4944b8cdbcae82fe
 
-hermes_auxiliary_compression_provider: main
+hermes_auxiliary_compression_provider: copilot
+hermes_auxiliary_compression_model: gpt-4o-mini
+hermes_auxiliary_compression_timeout: 90
 hermes_compression_threshold: 0.85
 hermes_compression_codex_gpt55_autoraise: false
 hermes_web_search_backend: parallel

--- a/infra/ansible/playbooks/validate.yml
+++ b/infra/ansible/playbooks/validate.yml
@@ -248,6 +248,33 @@
           python3 -c 'import os, sys; p = "{{ hermes_browser_browsers_path }}"; sys.exit(0 if os.path.isdir(p) and any(n.startswith("chrome-") for n in os.listdir(p)) else 1)'
       changed_when: false
 
+    - name: Check Hermes compression route
+      ansible.builtin.shell: |
+        {{ hermes_venv_path }}/bin/python - <<'PY'
+        from pathlib import Path
+        import yaml
+
+        config = yaml.safe_load(Path("{{ hermes_home }}/config.yaml").read_text(encoding="utf-8")) or {}
+        compression = (config.get("auxiliary") or {}).get("compression") or {}
+        checks = [
+            ("auxiliary.compression.provider", compression.get("provider"), "copilot"),
+            ("auxiliary.compression.model", compression.get("model"), "gpt-4o-mini"),
+            ("auxiliary.compression.timeout", compression.get("timeout"), 90),
+            ("auxiliary.compression.base_url", compression.get("base_url"), ""),
+            ("auxiliary.compression.api_key", compression.get("api_key"), ""),
+        ]
+        mismatches = [
+            f"{label}={actual!r} expected {expected!r}"
+            for label, actual, expected in checks
+            if actual != expected
+        ]
+        if mismatches:
+            raise SystemExit("; ".join(mismatches))
+        PY
+      args:
+        executable: /bin/bash
+      changed_when: false
+
     - name: Check Hermes 1Password CLI
       ansible.builtin.command:
         cmd: op --version

--- a/infra/ansible/roles/hermes/templates/hermes-configure-runtime.py.j2
+++ b/infra/ansible/roles/hermes/templates/hermes-configure-runtime.py.j2
@@ -9,6 +9,8 @@ import yaml
 
 CONFIG_PATH = Path("{{ hermes_home }}/config.yaml")
 DESIRED_COMPRESSION_PROVIDER = "{{ hermes_auxiliary_compression_provider }}"
+DESIRED_COMPRESSION_MODEL = "{{ hermes_auxiliary_compression_model | default('') }}"
+DESIRED_COMPRESSION_TIMEOUT = {{ hermes_auxiliary_compression_timeout | default(120) | int }}
 DESIRED_COMPRESSION_THRESHOLD = {{ hermes_compression_threshold | float }}
 DESIRED_CODEX_GPT55_AUTORAISE = {{ (hermes_compression_codex_gpt55_autoraise | bool) | ternary('True', 'False') }}
 DESIRED_WEB_SEARCH_BACKEND = "{{ hermes_web_search_backend }}"
@@ -60,8 +62,17 @@ def main():
     if compression.get("provider") != DESIRED_COMPRESSION_PROVIDER:
         compression["provider"] = DESIRED_COMPRESSION_PROVIDER
         changed = True
-    if compression.get("model") != "":
-        compression["model"] = ""
+    if compression.get("model") != DESIRED_COMPRESSION_MODEL:
+        compression["model"] = DESIRED_COMPRESSION_MODEL
+        changed = True
+    if compression.get("timeout") != DESIRED_COMPRESSION_TIMEOUT:
+        compression["timeout"] = DESIRED_COMPRESSION_TIMEOUT
+        changed = True
+    if compression.get("base_url") != "":
+        compression["base_url"] = ""
+        changed = True
+    if compression.get("api_key") != "":
+        compression["api_key"] = ""
         changed = True
 
     if runtime_compression.get("threshold") != DESIRED_COMPRESSION_THRESHOLD:

--- a/tests/hermes/test_hermes_edge_and_runbook.py
+++ b/tests/hermes/test_hermes_edge_and_runbook.py
@@ -138,6 +138,11 @@ def test_hermes_runbook_documents_discord_gateway_web_search_browser_automation_
     assert ".config/op" in runbook
     assert "threshold: 0.85" in runbook
     assert "codex_gpt55_autoraise: false" in runbook
+    assert "auxiliary:" in runbook
+    assert "provider: copilot" in runbook
+    assert "model: gpt-4o-mini" in runbook
+    assert "timeout: 90" in runbook
+    assert "Codex auxiliary Responses stream exceeded 120.0s" in runbook
     assert "rebuild_hermes_lxc" not in runbook
     assert 'module.lxc["hermes"].proxmox_virtual_environment_container.this' not in runbook
     assert "/workspace" in runbook

--- a/tests/hermes/test_hermes_role.py
+++ b/tests/hermes/test_hermes_role.py
@@ -235,15 +235,16 @@ def test_hermes_role_keeps_venv_writable_for_lazy_dependency_installs():
     assert agent_pip_index < ownership_index < service_index
 
 
-def test_hermes_role_routes_auxiliary_compression_to_main_provider():
+def test_hermes_role_routes_auxiliary_compression_to_fast_copilot_model():
     tasks = read_yaml("infra/ansible/roles/hermes/tasks/main.yml")
     group_vars = read_yaml("infra/ansible/inventory/prod/group_vars/svc_hermes.yml")
     script_path = REPO_ROOT / "infra/ansible/roles/hermes/templates/hermes-configure-runtime.py.j2"
     assert script_path.exists()
     script = script_path.read_text(encoding="utf-8")
 
-    assert group_vars["hermes_auxiliary_compression_provider"] == "main"
-    assert "hermes_auxiliary_compression_model" not in group_vars
+    assert group_vars["hermes_auxiliary_compression_provider"] == "copilot"
+    assert group_vars["hermes_auxiliary_compression_model"] == "gpt-4o-mini"
+    assert group_vars["hermes_auxiliary_compression_timeout"] == 90
 
     template_task = find_task(tasks, "Install Hermes runtime configuration helper")
     assert template_task["ansible.builtin.template"]["src"] == "hermes-configure-runtime.py.j2"
@@ -264,9 +265,32 @@ def test_hermes_role_routes_auxiliary_compression_to_main_provider():
     assert ownership_index < configure_index < service_index
 
     assert "hermes_auxiliary_compression_provider" in script
-    assert 'compression["model"] = ""' in script
+    assert "hermes_auxiliary_compression_model" in script
+    assert "hermes_auxiliary_compression_timeout" in script
+    assert 'compression["model"] = DESIRED_COMPRESSION_MODEL' in script
+    assert 'compression["timeout"] = DESIRED_COMPRESSION_TIMEOUT' in script
+    assert 'compression["base_url"] = ""' in script
+    assert 'compression["api_key"] = ""' in script
     assert "gpt-5.5" not in script
-    assert "api_key" not in script
+    assert "hermes_auxiliary_compression_api_key" not in script
+
+
+def test_validate_playbook_asserts_hermes_fast_compression_route():
+    validate = read_yaml("infra/ansible/playbooks/validate.yml")
+    hermes_play = next(
+        (play for play in validate if play.get("name") == "Validate hermes"),
+        None,
+    )
+
+    assert hermes_play is not None
+    hermes_tasks = yaml.safe_dump(hermes_play.get("tasks", []), sort_keys=True)
+    assert "Check Hermes compression route" in hermes_tasks
+    assert "auxiliary.compression.provider" in hermes_tasks
+    assert "auxiliary.compression.base_url" in hermes_tasks
+    assert "auxiliary.compression.api_key" in hermes_tasks
+    assert "copilot" in hermes_tasks
+    assert "gpt-4o-mini" in hermes_tasks
+    assert "gpt-5.5" not in hermes_tasks
 
 
 def test_hermes_role_configures_parallel_search_and_firecrawl_extract():


### PR DESCRIPTION
## Summary
- Fix Hermes compression summaries by routing `auxiliary.compression` away from the main Codex `gpt-5.5` Responses path that repeatedly hit `Codex auxiliary Responses stream exceeded 120.0s total timeout`.
- Set Hermes compression summaries to Copilot `gpt-4o-mini` with a 90s timeout in tracked Ansible group vars.
- Update the runtime config helper to enforce provider/model/timeout and clear stale `base_url` / `api_key` values that could override the intended route.
- Add a validate playbook assertion for the deployed compression route.
- Document the failure mode and Copilot credential requirement in the Hermes runbook.

## Root cause
Gateway logs showed compression summaries using the main model route:

```text
Auxiliary compression: using main (gpt-5.5) at https://chatgpt.com/backend-api/codex/
Codex auxiliary Responses stream exceeded 120.0s total timeout
Compression summary failed ... Inserted a fallback context marker
```

Because IaC configured `hermes_auxiliary_compression_provider: main`, summary generation used the same OpenAI Codex `gpt-5.5` Responses backend as the agent. Large compactions timed out and fell back to deterministic markers.

## Test Plan
- Wrote failing regression tests first for the fast compression route, validate playbook assertion, and runbook docs.
- Confirmed the targeted tests failed before implementation.
- Live smoke: `call_llm(provider='copilot', model='gpt-4o-mini', ...)` succeeds; unsupported Copilot models `gpt-5-mini` and `gpt-4.1-mini` were rejected, so this PR uses `gpt-4o-mini`.
- `PYTHONPATH=$PWD python -m pytest tests/hermes/test_hermes_role.py tests/hermes/test_hermes_infra.py tests/hermes/test_hermes_edge_and_runbook.py -q` → 33 passed
- `PYTHONPATH=$PWD python -m pytest -q` → 198 passed
- `PYTHONPATH=$PWD python scripts/ci/render_ansible_inventory.py --check`
- `ANSIBLE_CONFIG=infra/ansible/ansible.cfg ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/bootstrap.yml --syntax-check`
- `ANSIBLE_CONFIG=infra/ansible/ansible.cfg ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/site.yml --syntax-check`
- `ANSIBLE_CONFIG=infra/ansible/ansible.cfg ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/validate.yml --syntax-check`
- `python -m compileall -q scripts tests`
- `git diff --check`
- static scan findings: none
- Independent pre-commit review: no blockers, safe to commit

## Deployment notes
- Requires the existing persistent Copilot credential in `/var/lib/hermes/auth.json` to remain valid.
- `validate.yml` now fails if `auxiliary.compression` is not `provider=copilot`, `model=gpt-4o-mini`, `timeout=90`, with empty `base_url` and `api_key`.
