### PR TITLE
fix: increase Hermes compression timeout

### DIFF
--- a/docs/runbooks/hermes-agent-discord.md
+++ b/docs/runbooks/hermes-agent-discord.md
@@ -77,9 +77,14 @@ The runtime config helper also enforces Hermes' global context-compression behav
 compression:
   threshold: 0.85
   codex_gpt55_autoraise: false
+auxiliary:
+  compression:
+    provider: main
+    model: ""
+    timeout: 300
 ```
 
-This keeps the general compaction trigger at 85% and disables the Codex gpt-5.5 route-specific autoraise override, so the deployed gateway follows the tracked repo setting instead of an operator-only live edit.
+This keeps the general compaction trigger at 85%, disables the Codex gpt-5.5 route-specific autoraise override, and raises the compression-summary call timeout above the previous 120s live setting that produced `Codex auxiliary Responses stream exceeded 120.0s total timeout`. The summary provider remains `main`, so compression continues to use the configured main Hermes model route with a longer budget instead of an operator-only live edit.
 
 ## Discord setup
 

--- a/infra/ansible/inventory/prod/group_vars/svc_hermes.yml
+++ b/infra/ansible/inventory/prod/group_vars/svc_hermes.yml
@@ -14,6 +14,7 @@ hermes_agent_repo: https://github.com/NousResearch/hermes-agent.git
 hermes_agent_ref: 36ae958473b8530ffb1a395c4944b8cdbcae82fe
 
 hermes_auxiliary_compression_provider: main
+hermes_auxiliary_compression_timeout: 300
 hermes_compression_threshold: 0.85
 hermes_compression_codex_gpt55_autoraise: false
 hermes_web_search_backend: parallel

--- a/infra/ansible/playbooks/validate.yml
+++ b/infra/ansible/playbooks/validate.yml
@@ -248,6 +248,31 @@
           python3 -c 'import os, sys; p = "{{ hermes_browser_browsers_path }}"; sys.exit(0 if os.path.isdir(p) and any(n.startswith("chrome-") for n in os.listdir(p)) else 1)'
       changed_when: false
 
+    - name: Check Hermes compression timeout
+      ansible.builtin.shell: |
+        {{ hermes_venv_path }}/bin/python - <<'PY'
+        from pathlib import Path
+        import yaml
+
+        config = yaml.safe_load(Path("{{ hermes_home }}/config.yaml").read_text(encoding="utf-8")) or {}
+        compression = (config.get("auxiliary") or {}).get("compression") or {}
+        checks = [
+            ("auxiliary.compression.provider", compression.get("provider"), "main"),
+            ("auxiliary.compression.model", compression.get("model"), ""),
+            ("auxiliary.compression.timeout", compression.get("timeout"), 300),
+        ]
+        mismatches = [
+            f"{label}={actual!r} expected {expected!r}"
+            for label, actual, expected in checks
+            if actual != expected
+        ]
+        if mismatches:
+            raise SystemExit("; ".join(mismatches))
+        PY
+      args:
+        executable: /bin/bash
+      changed_when: false
+
     - name: Check Hermes 1Password CLI
       ansible.builtin.command:
         cmd: op --version

--- a/infra/ansible/roles/hermes/templates/hermes-configure-runtime.py.j2
+++ b/infra/ansible/roles/hermes/templates/hermes-configure-runtime.py.j2
@@ -9,6 +9,7 @@ import yaml
 
 CONFIG_PATH = Path("{{ hermes_home }}/config.yaml")
 DESIRED_COMPRESSION_PROVIDER = "{{ hermes_auxiliary_compression_provider }}"
+DESIRED_COMPRESSION_TIMEOUT = {{ hermes_auxiliary_compression_timeout | int }}
 DESIRED_COMPRESSION_THRESHOLD = {{ hermes_compression_threshold | float }}
 DESIRED_CODEX_GPT55_AUTORAISE = {{ (hermes_compression_codex_gpt55_autoraise | bool) | ternary('True', 'False') }}
 DESIRED_WEB_SEARCH_BACKEND = "{{ hermes_web_search_backend }}"
@@ -62,6 +63,9 @@ def main():
         changed = True
     if compression.get("model") != "":
         compression["model"] = ""
+        changed = True
+    if compression.get("timeout") != DESIRED_COMPRESSION_TIMEOUT:
+        compression["timeout"] = DESIRED_COMPRESSION_TIMEOUT
         changed = True
 
     if runtime_compression.get("threshold") != DESIRED_COMPRESSION_THRESHOLD:

--- a/tests/hermes/test_hermes_edge_and_runbook.py
+++ b/tests/hermes/test_hermes_edge_and_runbook.py
@@ -138,6 +138,10 @@ def test_hermes_runbook_documents_discord_gateway_web_search_browser_automation_
     assert ".config/op" in runbook
     assert "threshold: 0.85" in runbook
     assert "codex_gpt55_autoraise: false" in runbook
+    assert "auxiliary:" in runbook
+    assert "provider: main" in runbook
+    assert "timeout: 300" in runbook
+    assert "Codex auxiliary Responses stream exceeded 120.0s" in runbook
     assert "rebuild_hermes_lxc" not in runbook
     assert 'module.lxc["hermes"].proxmox_virtual_environment_container.this' not in runbook
     assert "/workspace" in runbook

--- a/tests/hermes/test_hermes_role.py
+++ b/tests/hermes/test_hermes_role.py
@@ -235,7 +235,7 @@ def test_hermes_role_keeps_venv_writable_for_lazy_dependency_installs():
     assert agent_pip_index < ownership_index < service_index
 
 
-def test_hermes_role_routes_auxiliary_compression_to_main_provider():
+def test_hermes_role_routes_auxiliary_compression_to_main_provider_with_longer_timeout():
     tasks = read_yaml("infra/ansible/roles/hermes/tasks/main.yml")
     group_vars = read_yaml("infra/ansible/inventory/prod/group_vars/svc_hermes.yml")
     script_path = REPO_ROOT / "infra/ansible/roles/hermes/templates/hermes-configure-runtime.py.j2"
@@ -243,6 +243,7 @@ def test_hermes_role_routes_auxiliary_compression_to_main_provider():
     script = script_path.read_text(encoding="utf-8")
 
     assert group_vars["hermes_auxiliary_compression_provider"] == "main"
+    assert group_vars["hermes_auxiliary_compression_timeout"] == 300
     assert "hermes_auxiliary_compression_model" not in group_vars
 
     template_task = find_task(tasks, "Install Hermes runtime configuration helper")
@@ -264,9 +265,27 @@ def test_hermes_role_routes_auxiliary_compression_to_main_provider():
     assert ownership_index < configure_index < service_index
 
     assert "hermes_auxiliary_compression_provider" in script
+    assert "hermes_auxiliary_compression_timeout" in script
     assert 'compression["model"] = ""' in script
+    assert 'compression["timeout"] = DESIRED_COMPRESSION_TIMEOUT' in script
     assert "gpt-5.5" not in script
     assert "api_key" not in script
+
+
+def test_validate_playbook_asserts_hermes_compression_timeout():
+    validate = read_yaml("infra/ansible/playbooks/validate.yml")
+    hermes_play = next(
+        (play for play in validate if play.get("name") == "Validate hermes"),
+        None,
+    )
+
+    assert hermes_play is not None
+    hermes_tasks = yaml.safe_dump(hermes_play.get("tasks", []), sort_keys=True)
+    assert "Check Hermes compression timeout" in hermes_tasks
+    assert "auxiliary.compression.provider" in hermes_tasks
+    assert "auxiliary.compression.timeout" in hermes_tasks
+    assert "main" in hermes_tasks
+    assert "300" in hermes_tasks
 
 
 def test_hermes_role_configures_parallel_search_and_firecrawl_extract():


### PR DESCRIPTION
## Summary
- Replace the prior Copilot-routing approach with a timeout-only fix for Hermes compression summaries.
- Keep `auxiliary.compression.provider` on `main` and `model` blank, but render `auxiliary.compression.timeout: 300` from Ansible.
- Add deploy validation that `/var/lib/hermes/config.yaml` has `provider=main`, `model=""`, and `timeout=300`.
- Document the previous 120s live timeout failure in the Hermes Discord gateway runbook.

## Context
The previous PR that routed compression to Copilot was closed and its branch deleted per maintainer request. This PR keeps compression on the main Hermes model route and raises the timeout above the live 120s setting that produced:

```text
Codex auxiliary Responses stream exceeded 120.0s total timeout
```

## Test Plan
- Wrote failing regression tests first for the longer timeout, validate playbook assertion, and runbook documentation.
- Confirmed the targeted tests failed before implementation.
- `PYTHONPATH=$PWD python -m pytest tests/hermes/test_hermes_role.py tests/hermes/test_hermes_infra.py tests/hermes/test_hermes_edge_and_runbook.py -q` → 33 passed
- `PYTHONPATH=$PWD python -m pytest -q` → 198 passed
- `PYTHONPATH=$PWD python scripts/ci/render_ansible_inventory.py --check`
- `ANSIBLE_CONFIG=infra/ansible/ansible.cfg ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/bootstrap.yml --syntax-check`
- `ANSIBLE_CONFIG=infra/ansible/ansible.cfg ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/site.yml --syntax-check`
- `ANSIBLE_CONFIG=infra/ansible/ansible.cfg ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/validate.yml --syntax-check`
- `python -m compileall -q scripts tests`
- `git diff --check`
- static scan findings: none
- Independent pre-commit review: no blockers, safe to commit

## Replaces
- Closed PR #87 and deleted branch `fix/hermes-compression-timeout` per maintainer request.
