### PR TITLE
fix: secure Hermes 1Password config mode

### DIFF
--- a/docs/runbooks/hermes-agent-discord.md
+++ b/docs/runbooks/hermes-agent-discord.md
@@ -67,7 +67,7 @@ op read "op://Vault/Item/field"
 op run -- env | grep '^EXAMPLE_'
 ```
 
-Do not ask Hermes to print raw secret values unless you explicitly need to reveal one; prefer `op run` and `op inject` for commands and templates. Scope the 1Password service account narrowly to the vaults/items Hermes is allowed to read, because allowed Discord users can ask Hermes to run terminal commands that use this token. The role keeps `/var/lib/hermes/.config/op` owned by the `hermes` service user so validation and service commands do not leave root-owned 1Password CLI state behind.
+Do not ask Hermes to print raw secret values unless you explicitly need to reveal one; prefer `op run` and `op inject` for commands and templates. Scope the 1Password service account narrowly to the vaults/items Hermes is allowed to read, because allowed Discord users can ask Hermes to run terminal commands that use this token. The role keeps `/var/lib/hermes/.config/op` owned by the `hermes` service user and keeps `/var/lib/hermes/.config/op/config` at mode `0600`, because the 1Password CLI refuses to read that config file when its permissions are broader.
 
 ## Context compression
 

--- a/infra/ansible/playbooks/validate.yml
+++ b/infra/ansible/playbooks/validate.yml
@@ -283,6 +283,36 @@
         cmd: test -f "{{ hermes_home }}/skills/security/1password/SKILL.md"
       changed_when: false
 
+    - name: Check Hermes 1Password CLI config file mode
+      ansible.builtin.shell: |
+        {{ hermes_venv_path }}/bin/python - <<'PY'
+        from pathlib import Path
+        import pwd
+        import grp
+        import stat
+
+        path = Path("{{ hermes_home }}/.config/op/config")
+        if not path.exists():
+            raise SystemExit(0)
+        if path.is_symlink():
+            raise SystemExit(f"{path} must not be a symlink")
+        st = path.stat()
+        expected_uid = pwd.getpwnam("{{ hermes_user }}").pw_uid
+        expected_gid = grp.getgrnam("{{ hermes_group }}").gr_gid
+        failures = []
+        if st.st_uid != expected_uid:
+            failures.append(f"owner uid {st.st_uid} != {expected_uid}")
+        if st.st_gid != expected_gid:
+            failures.append(f"group gid {st.st_gid} != {expected_gid}")
+        if stat.S_IMODE(st.st_mode) != 0o600:
+            failures.append(f"mode {stat.S_IMODE(st.st_mode):04o} != 0600")
+        if failures:
+            raise SystemExit("; ".join(failures))
+        PY
+      args:
+        executable: /bin/bash
+      changed_when: false
+
     - name: Check Hermes 1Password service account authentication
       ansible.builtin.shell: |
         set -euo pipefail

--- a/infra/ansible/roles/hermes/tasks/main.yml
+++ b/infra/ansible/roles/hermes/tasks/main.yml
@@ -179,7 +179,22 @@
     owner: "{{ hermes_user }}"
     group: "{{ hermes_group }}"
     mode: "0700"
-    recurse: true
+
+- name: Check Hermes 1Password CLI config file
+  ansible.builtin.stat:
+    path: "{{ hermes_home }}/.config/op/config"
+    follow: false
+  register: hermes_op_config_file
+
+- name: Secure Hermes 1Password CLI config file
+  ansible.builtin.file:
+    path: "{{ hermes_home }}/.config/op/config"
+    state: file
+    owner: "{{ hermes_user }}"
+    group: "{{ hermes_group }}"
+    mode: "0600"
+    follow: false
+  when: hermes_op_config_file.stat.exists
 
 - name: Check Hermes browser automation CLI
   ansible.builtin.stat:

--- a/tests/hermes/test_hermes_edge_and_runbook.py
+++ b/tests/hermes/test_hermes_edge_and_runbook.py
@@ -84,6 +84,10 @@ def test_validate_playbook_checks_hermes_gateway_service_and_browser_cli():
     assert "op whoami" in hermes_tasks
     assert "runuser -u" in hermes_tasks
     assert "OP_SERVICE_ACCOUNT_TOKEN" in hermes_tasks
+    assert "Check Hermes 1Password CLI config file mode" in hermes_tasks
+    assert "path.is_symlink()" in hermes_tasks
+    assert "stat.S_IMODE(st.st_mode)" in hermes_tasks
+    assert "0o600" in hermes_tasks
     assert "chromium-" not in hermes_tasks
     assert "hermes-webui" not in hermes_tasks
     assert "hermes_webui_port" not in hermes_tasks
@@ -136,6 +140,7 @@ def test_hermes_runbook_documents_discord_gateway_web_search_browser_automation_
     assert "op read" in runbook
     assert "op run" in runbook
     assert ".config/op" in runbook
+    assert "0600" in runbook
     assert "threshold: 0.85" in runbook
     assert "codex_gpt55_autoraise: false" in runbook
     assert "auxiliary:" in runbook

--- a/tests/hermes/test_hermes_role.py
+++ b/tests/hermes/test_hermes_role.py
@@ -108,7 +108,25 @@ def test_hermes_role_installs_1password_cli_and_skill_for_secret_access():
     assert op_config_task["ansible.builtin.file"]["owner"] == "{{ hermes_user }}"
     assert op_config_task["ansible.builtin.file"]["group"] == "{{ hermes_group }}"
     assert op_config_task["ansible.builtin.file"]["mode"] == "0700"
-    assert op_config_task["ansible.builtin.file"]["recurse"] is True
+    assert "recurse" not in op_config_task["ansible.builtin.file"]
+
+    op_config_file_check_task = find_task(tasks, "Check Hermes 1Password CLI config file")
+    assert op_config_file_check_task["ansible.builtin.stat"]["path"] == (
+        "{{ hermes_home }}/.config/op/config"
+    )
+    assert op_config_file_check_task["ansible.builtin.stat"]["follow"] is False
+    assert op_config_file_check_task["register"] == "hermes_op_config_file"
+
+    op_config_file_task = find_task(tasks, "Secure Hermes 1Password CLI config file")
+    assert op_config_file_task["ansible.builtin.file"]["path"] == (
+        "{{ hermes_home }}/.config/op/config"
+    )
+    assert op_config_file_task["ansible.builtin.file"]["state"] == "file"
+    assert op_config_file_task["ansible.builtin.file"]["owner"] == "{{ hermes_user }}"
+    assert op_config_file_task["ansible.builtin.file"]["group"] == "{{ hermes_group }}"
+    assert op_config_file_task["ansible.builtin.file"]["mode"] == "0600"
+    assert op_config_file_task["ansible.builtin.file"]["follow"] is False
+    assert op_config_file_task["when"] == "hermes_op_config_file.stat.exists"
 
     runtime_package_index = tasks.index(find_task(tasks, "Install Hermes runtime packages"))
     key_index = tasks.index(key_task)
@@ -119,9 +137,20 @@ def test_hermes_role_installs_1password_cli_and_skill_for_secret_access():
     skill_index = tasks.index(skill_task)
     ownership_index = tasks.index(ownership_task)
     op_config_index = tasks.index(op_config_task)
+    op_config_file_check_index = tasks.index(op_config_file_check_task)
+    op_config_file_index = tasks.index(op_config_file_task)
     service_index = tasks.index(find_task(tasks, "Enable Hermes gateway"))
     assert runtime_package_index < key_index < repo_index < op_index
-    assert agent_pip_index < skill_check_index < skill_index < ownership_index < op_config_index < service_index
+    assert (
+        agent_pip_index
+        < skill_check_index
+        < skill_index
+        < ownership_index
+        < op_config_index
+        < op_config_file_check_index
+        < op_config_file_index
+        < service_index
+    )
 
 
 def test_hermes_role_installs_agent_browser_node_dependencies():


### PR DESCRIPTION
## Summary
- Fix the post-merge CD validation failure in `Check Hermes 1Password service account authentication`.
- Stop recursively applying `0700` to `/var/lib/hermes/.config/op`, which also made `config` too broad for the 1Password CLI.
- Secure `/var/lib/hermes/.config/op/config` to `0600` when it exists, owned by the Hermes service user/group.
- Add validate coverage for the config file owner/group/mode before the no-log `op whoami` step, plus docs/tests.

## Root cause
The linked run failed after PR #88, but the compression timeout validation itself passed. The failing task was:

```text
TASK [Check Hermes 1Password service account authentication]
```

This same task also failed after PR #86. The task output was hidden by `no_log`, so I reproduced the failure locally with the same Hermes home:

```text
/var/lib/hermes/.config/op/config mode: 700
op whoami -> cannot read config ... permissions are too broad. Change its permissions to 600 and try again.
```

After `chmod 600 /var/lib/hermes/.config/op/config`, local `op whoami` succeeded as `SERVICE_ACCOUNT`.

The IaC issue was the recursive `mode: "0700"` on `/var/lib/hermes/.config/op`, which also chmodded the `config` file to `0700`. 1Password CLI requires the config file to be `0600`.

## Test Plan
- Wrote failing regression tests first for the role, validate playbook, and runbook.
- Local live reproduction: `op whoami` failed with config mode `700`; after `chmod 600`, it succeeded as `SERVICE_ACCOUNT`.
- `PYTHONPATH=$PWD python -m pytest tests/hermes/test_hermes_role.py tests/hermes/test_hermes_infra.py tests/hermes/test_hermes_edge_and_runbook.py -q` → 33 passed
- `PYTHONPATH=$PWD python -m pytest -q` → 198 passed
- `PYTHONPATH=$PWD python scripts/ci/render_ansible_inventory.py --check`
- `ANSIBLE_CONFIG=infra/ansible/ansible.cfg ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/bootstrap.yml --syntax-check`
- `ANSIBLE_CONFIG=infra/ansible/ansible.cfg ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/site.yml --syntax-check`
- `ANSIBLE_CONFIG=infra/ansible/ansible.cfg ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/validate.yml --syntax-check`
- `python -m compileall -q scripts tests`
- `git diff --check`
- static scan findings: none
- Independent pre-commit review: no blockers, safe to commit
