### PR TITLE
fix: verify Hermes Newrrow login runtime

### DIFF
--- a/docs/runbooks/hermes-agent-discord.md
+++ b/docs/runbooks/hermes-agent-discord.md
@@ -76,8 +76,8 @@ The role installs a local Hermes skill at `/var/lib/hermes/skills/productivity/n
 Newrrow login uses 1Password secret references instead of live browser password-manager state. The tracked inventory configures:
 
 ```yaml
-hermes_newrrow_username_ref: op://Hermes/뉴로우/username
-hermes_newrrow_password_ref: op://Hermes/뉴로우/password
+hermes_newrrow_username_ref: op://Hermes/Newrrow/username
+hermes_newrrow_password_ref: op://Hermes/Newrrow/password
 ```
 
 Ansible renders those into `/etc/hermes-gateway.env` as `NEWRROW_USERNAME_REF` and `NEWRROW_PASSWORD_REF`. The Newrrow URL is hardcoded in the skill/helper as `https://gbsm.newrrow.com/csr-platform/home` instead of being exposed as gateway environment. Ensure the Hermes 1Password service account can read the referenced item fields, then ask Hermes to use `$newrrow-points-automation`.
@@ -88,7 +88,7 @@ If Newrrow presents a login page, the skill directs Hermes to run:
 bash "$HERMES_HOME/skills/productivity/newrrow-points-automation/scripts/newrrow-login.sh"
 ```
 
-The helper reads the configured `op://` refs with `op read`, sends the password only through `agent-browser auth save --password-stdin`, runs `agent-browser auth login`, and deletes the temporary auth profile. Do not print the Newrrow username/password values in Discord or logs.
+The helper reads the configured `op://` refs with `op read`, sends the password only through `agent-browser auth save --password-stdin`, runs `agent-browser auth login`, falls back to clicking the visible `로그인` button when the auth helper fills fields but fails to submit, handles the first-run `뉴로우 시작하기` invitation screen, and deletes the temporary auth profile. Do not print the Newrrow username/password values in Discord or logs.
 
 ## Context compression
 

--- a/infra/ansible/inventory/prod/group_vars/svc_hermes.yml
+++ b/infra/ansible/inventory/prod/group_vars/svc_hermes.yml
@@ -26,8 +26,8 @@ hermes_browser_args: --no-sandbox,--disable-dev-shm-usage
 hermes_browserbase_proxies: true
 hermes_browserbase_advanced_stealth: false
 
-hermes_newrrow_username_ref: op://Hermes/뉴로우/username
-hermes_newrrow_password_ref: op://Hermes/뉴로우/password
+hermes_newrrow_username_ref: op://Hermes/Newrrow/username
+hermes_newrrow_password_ref: op://Hermes/Newrrow/password
 
 hermes_discord_require_mention: true
 hermes_discord_ignore_no_mention: true

--- a/infra/ansible/roles/hermes/files/skills/newrrow-points-automation/SKILL.md
+++ b/infra/ansible/roles/hermes/files/skills/newrrow-points-automation/SKILL.md
@@ -41,7 +41,7 @@ If Newrrow asks for login, use 1Password instead of browser password managers. P
 bash "$HERMES_HOME/skills/productivity/newrrow-points-automation/scripts/newrrow-login.sh"
 ```
 
-The helper uses `op read` against `NEWRROW_USERNAME_REF` and `NEWRROW_PASSWORD_REF`, pipes the password to `agent-browser auth save --password-stdin`, runs `agent-browser auth login`, and deletes the temporary auth profile afterward. Do not echo, print, log, or include the secret values in the final answer.
+The helper reads `NEWRROW_USERNAME_REF` and `NEWRROW_PASSWORD_REF` with `op read`, pipes the password to `agent-browser auth save --password-stdin`, runs `agent-browser auth login`, falls back to clicking the visible `로그인` button when the auth helper fills the fields but fails to submit, handles the first-run `뉴로우 시작하기` invitation screen, and deletes the temporary auth profile afterward. Do not echo, print, log, or include the secret values in the final answer.
 
 If the helper cannot read the configured 1Password refs, report the missing ref names and ask the user to update the 1Password item or IaC variables. If Newrrow requires 2FA, CAPTCHA, account chooser, or another visible security prompt, stop and ask the user to complete that step.
 

--- a/infra/ansible/roles/hermes/files/skills/newrrow-points-automation/scripts/newrrow-login.sh
+++ b/infra/ansible/roles/hermes/files/skills/newrrow-points-automation/scripts/newrrow-login.sh
@@ -16,7 +16,7 @@ if [ ! -x "$AGENT_BROWSER_BIN" ]; then
   exit 1
 fi
 
-# Read credentials with op read through the configurable OP_BIN.
+# Read credentials through op without printing secret values.
 username="$($OP_BIN read "$NEWRROW_USERNAME_REF")"
 newrrow_pw="$($OP_BIN read "$NEWRROW_PASSWORD_REF")"
 
@@ -37,15 +37,61 @@ printf '%s' "$newrrow_pw" | "$AGENT_BROWSER_BIN" auth save "$NEWRROW_AUTH_NAME" 
   --username "$username" \
   --password-stdin >/dev/null
 
-"$AGENT_BROWSER_BIN" open "$newrrow_home_url" >/dev/null
-snapshot="$($AGENT_BROWSER_BIN snapshot -i 2>/dev/null || true)"
-current_url="$($AGENT_BROWSER_BIN get url 2>/dev/null || true)"
+refresh_page_state() {
+  snapshot="$($AGENT_BROWSER_BIN snapshot -i 2>/dev/null || true)"
+  current_url="$($AGENT_BROWSER_BIN get url 2>/dev/null || true)"
+}
 
-if printf '%s\n%s\n' "$current_url" "$snapshot" | grep -Eiq 'login|로그인|password|비밀번호|아이디|email'; then
-  "$AGENT_BROWSER_BIN" auth login "$NEWRROW_AUTH_NAME" >/dev/null
-  "$AGENT_BROWSER_BIN" wait 2000 >/dev/null || true
+click_visible_login_button() {
+  local login_ref=""
+  refresh_page_state
+  login_ref="$(printf '%s\n' "$snapshot" | sed -n 's/.*button "로그인".*\[ref=\(e[0-9][0-9]*\)\].*/@\1/p' | head -1)"
+  if [ -n "$login_ref" ]; then
+    "$AGENT_BROWSER_BIN" click "$login_ref" >/dev/null 2>&1
+  else
+    "$AGENT_BROWSER_BIN" find text "로그인" click --exact >/dev/null 2>&1
+  fi
+}
+
+wait_for_newrrow_state() {
+  local _
+  for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
+    refresh_page_state
+    if printf '%s\n%s\n' "$current_url" "$snapshot" \
+      | grep -Eiq 'login|로그인|password|비밀번호|아이디|이메일|csr-platform/(home|invitation)|뉴로우 시작하기|오늘 할 일'; then
+      return 0
+    fi
+    "$AGENT_BROWSER_BIN" wait 1000 >/dev/null || true
+  done
+  refresh_page_state
+}
+
+"$AGENT_BROWSER_BIN" open "$newrrow_home_url" >/dev/null
+wait_for_newrrow_state
+
+if printf '%s\n%s\n' "$current_url" "$snapshot" | grep -Eiq 'login|로그인|password|비밀번호|아이디|이메일'; then
+  if ! "$AGENT_BROWSER_BIN" auth login "$NEWRROW_AUTH_NAME" >/dev/null 2>&1; then
+    click_visible_login_button || true
+  fi
+  "$AGENT_BROWSER_BIN" wait 5000 >/dev/null || true
   "$AGENT_BROWSER_BIN" open "$newrrow_home_url" >/dev/null || true
+  wait_for_newrrow_state
+fi
+
+refresh_page_state
+current_url="$($AGENT_BROWSER_BIN get url 2>/dev/null || true)"
+if printf '%s\n%s\n' "$current_url" "$snapshot" | grep -Eq 'csr-platform/invitation|뉴로우 시작하기'; then
+  "$AGENT_BROWSER_BIN" find text "뉴로우 시작하기" click --exact >/dev/null 2>&1 || true
+  "$AGENT_BROWSER_BIN" wait 5000 >/dev/null || true
+  "$AGENT_BROWSER_BIN" open "$newrrow_home_url" >/dev/null || true
+  wait_for_newrrow_state
+fi
+
+current_url="$($AGENT_BROWSER_BIN get url 2>/dev/null || true)"
+if printf '%s\n' "$current_url" | grep -Eiq 'login|auth\.inhrplus\.com'; then
+  printf 'Newrrow login did not reach an authenticated page\n' >&2
+  exit 1
 fi
 
 printf 'newrrow_login_ready\n'
-"$AGENT_BROWSER_BIN" get url 2>/dev/null || true
+printf '%s\n' "$current_url"

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -24,7 +24,7 @@ Expected encrypted values:
 Non-secret deployment values:
 
 - `adguard_admin_username`, optional; defaults to `admin`
-- `hermes_newrrow_username_ref` and `hermes_newrrow_password_ref`, as 1Password secret references (for example `op://Hermes/뉴로우/username` and `op://Hermes/뉴로우/password`) read by the Hermes Newrrow skill at runtime
+- `hermes_newrrow_username_ref` and `hermes_newrrow_password_ref`, as 1Password secret references (for example `op://Hermes/Newrrow/username` and `op://Hermes/Newrrow/password`) read by the Hermes Newrrow skill at runtime
 
 GitHub Actions secret names for the Hermes web, browser, and 1Password backends are `PARALLEL_API_KEY`, `FIRECRAWL_API_KEY`, `BROWSERBASE_API_KEY`, `BROWSERBASE_PROJECT_ID`, and `OP_SERVICE_ACCOUNT_TOKEN`; the CD helper maps them to `hermes_parallel_api_key`, `hermes_firecrawl_api_key`, `hermes_browserbase_api_key`, `hermes_browserbase_project_id`, and `hermes_1password_service_account_token` for Ansible.
 

--- a/tests/hermes/test_hermes_role.py
+++ b/tests/hermes/test_hermes_role.py
@@ -167,8 +167,8 @@ def test_hermes_role_installs_newrrow_points_skill_with_1password_login():
     assert "hermes_newrrow_base_url" not in group_vars
     assert "hermes_newrrow_home_url" not in group_vars
     assert "hermes_newrrow_login_url" not in group_vars
-    assert group_vars["hermes_newrrow_username_ref"] == "op://Hermes/뉴로우/username"
-    assert group_vars["hermes_newrrow_password_ref"] == "op://Hermes/뉴로우/password"
+    assert group_vars["hermes_newrrow_username_ref"] == "op://Hermes/Newrrow/username"
+    assert group_vars["hermes_newrrow_password_ref"] == "op://Hermes/Newrrow/password"
 
     assert "NEWRROW_BASE_URL" not in env_template
     assert "NEWRROW_HOME_URL" not in env_template
@@ -199,8 +199,14 @@ def test_hermes_role_installs_newrrow_points_skill_with_1password_login():
     assert "https://gbsm.newrrow.com/csr-platform/home" in ui_flow
     assert "Proton Pass" not in ui_flow
 
-    assert "op read" in login_helper
+    assert "$OP_BIN read" in login_helper
+    assert "op item get" not in login_helper
+    assert "op://Hermes/뉴로우" not in login_helper
     assert "agent-browser auth save" in login_helper
+    assert "click_visible_login_button" in login_helper
+    assert "button \"로그인\"" in login_helper
+    assert "find text \"뉴로우 시작하기\" click --exact" in login_helper
+    assert "Newrrow login did not reach an authenticated page" in login_helper
     assert "--password-stdin" in login_helper
     assert "agent-browser auth delete" in login_helper
     assert "NEWRROW_BASE_URL" not in login_helper


### PR DESCRIPTION
## Summary
- Migrates the provided `newrrow-points-automation` skill into homelab-managed Hermes IaC instead of editing the live `/var/lib/hermes` environment.
- Installs the skill under `/var/lib/hermes/skills/productivity/newrrow-points-automation` with its Newrrow UI flow reference and a `newrrow-login.sh` helper.
- Adds only Newrrow 1Password ref env vars (`NEWRROW_USERNAME_REF`, `NEWRROW_PASSWORD_REF`) so Hermes can log in with `op read` + `agent-browser auth save --password-stdin` without printing secrets.
- Uses English 1Password item refs: `op://Hermes/Newrrow/username` and `op://Hermes/Newrrow/password`.
- Keeps the Newrrow URL hardcoded in the skill/helper as `https://gbsm.newrrow.com/csr-platform/home`; no `NEWRROW_*_URL` gateway env vars are rendered.
- Adds real-runtime login hardening: waits for Newrrow/auth pages, falls back to clicking the visible `로그인` button if `agent-browser auth login` fills fields but does not submit, handles the first-run `뉴로우 시작하기` invitation page, and fails if still stuck on auth.
- Adds Ansible validation and runbook coverage for the deployed skill/helper.

## Runtime blocker found and fixed
- Direct testing showed Korean refs like `op://Hermes/뉴로우/username` are rejected by `op read`; switching the item ref to English fixes the 1Password blocker.
- Direct testing also showed `agent-browser auth login` can fill Newrrow credentials but fail to submit with a transient daemon read error. The helper now parses the visible `로그인` button ref from the snapshot and clicks it as a fallback.
- Direct testing showed first login can land on `/csr-platform/invitation`; the helper now clicks `뉴로우 시작하기` and returns to `/csr-platform/home`.

## Test Plan
- Direct runtime test with real 1Password refs and agent-browser:
  - `op read op://Hermes/Newrrow/username` → success, non-empty
  - `op read op://Hermes/Newrrow/password` → success, non-empty
  - `newrrow-login.sh` → `newrrow_login_ready`, final URL `https://gbsm.newrrow.com/csr-platform/home`
  - Browser snapshot after helper showed authenticated Newrrow home with `홈`, `CSR 질문`, `할 일`, `훈련 기본 과정`, `과제`, `대시보드`, and today task cards visible.
- `PYTHONPATH=$PWD python -m pytest tests/hermes/test_hermes_role.py tests/hermes/test_hermes_infra.py tests/hermes/test_hermes_edge_and_runbook.py -q` → 34 passed
- `PYTHONPATH=$PWD python -m pytest -q` → 199 passed
- `PYTHONPATH=$PWD python scripts/ci/render_ansible_inventory.py --check`
- `ANSIBLE_CONFIG=infra/ansible/ansible.cfg ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/bootstrap.yml --syntax-check`
- `ANSIBLE_CONFIG=infra/ansible/ansible.cfg ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/site.yml --syntax-check`
- `ANSIBLE_CONFIG=infra/ansible/ansible.cfg ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/validate.yml --syntax-check`
- `bash -n infra/ansible/roles/hermes/files/skills/newrrow-points-automation/scripts/newrrow-login.sh`
- `python -m compileall -q scripts tests`
- `git diff --check`
- Static scan including untracked files: none
