### PR TITLE
fix: enforce Hermes config ownership boundary

### DIFF
--- a/docs/runbooks/hermes-agent-discord.md
+++ b/docs/runbooks/hermes-agent-discord.md
@@ -43,6 +43,8 @@ web:
 
 That gives Hermes Parallel-backed search results and Firecrawl-backed page extraction/scraping. The runtime config helper preserves the existing model/provider settings while enforcing these web backend settings.
 
+`homelab` is the canonical owner for runtime/environment-derived config keys: `web.*`, `browser.*`, `compression.*`, `auxiliary.compression.*`, `plugins.enabled`, and `platform_toolsets.discord`. The live `hermes-config/config/default/config.yaml` must not set those keys; the apply helper rejects them so a remote live-config push cannot silently override IaC-owned runtime values. To change one of those values, update homelab inventory/templates and redeploy.
+
 ## Browser automation
 
 Hermes browser automation is enabled for the Discord gateway with Browserbase cloud browsing:
@@ -55,13 +57,14 @@ platform_toolsets:
   discord:
     - hermes-discord
     - browser
+    - kanban
 ```
 
 The Ansible role installs Node.js/npm and the `agent-browser` package from the pinned Hermes Agent checkout. Browserbase hosts Chromium for public cloud sessions. Because `auto_local_for_private_urls: true` keeps LAN/localhost URLs out of Browserbase, the role also installs a local browser runtime under `/var/lib/hermes/.agent-browser/browsers` with `HOME=/var/lib/hermes` so Hermes' local sidecar can handle private targets.
 
 ## 1Password secrets
 
-Hermes can use 1Password-managed secrets from Discord through its terminal tools. The Ansible role installs the official 1Password CLI (`op`) from the 1Password Debian apt repository, installs the Hermes optional skill `official/security/1password` into `/var/lib/hermes/skills/security/1password`, and exposes `OP_SERVICE_ACCOUNT_TOKEN` to the gateway service. Use the service-account flow rather than desktop-app sign-in for the headless LXC.
+Hermes can use 1Password-managed secrets from Discord through its terminal tools. The Ansible role installs the official 1Password CLI (`op`) from the 1Password Debian apt repository and exposes `OP_SERVICE_ACCOUNT_TOKEN` to the gateway service. The Hermes `1password` skill itself is owned by the live `holybaechu/hermes-config` checkout at `/var/lib/hermes/skills/security/1password`; homelab validates that file exists and fails the deploy if the live config repo removed it instead of reinstalling it into the symlinked skills tree.
 
 Examples Hermes can run after deploy:
 

--- a/infra/ansible/playbooks/validate.yml
+++ b/infra/ansible/playbooks/validate.yml
@@ -320,11 +320,12 @@
 
         config = yaml.safe_load(Path("{{ hermes_home }}/config.yaml").read_text(encoding="utf-8")) or {}
         enabled = ((config.get("plugins") or {}).get("enabled") or [])
-        if "newrrow-browser-login" not in enabled:
-            raise SystemExit("newrrow-browser-login plugin is not enabled")
+        if enabled != ["newrrow-browser-login"]:
+            raise SystemExit(f"enabled plugins mismatch: {enabled!r}")
         toolsets = ((config.get("platform_toolsets") or {}).get("discord") or [])
-        if "browser" not in toolsets:
-            raise SystemExit("discord platform is missing browser toolset")
+        expected_toolsets = ["hermes-discord", "browser", "kanban"]
+        if toolsets != expected_toolsets:
+            raise SystemExit(f"discord platform toolsets mismatch: {toolsets!r}")
         PY
       args:
         executable: /bin/bash

--- a/infra/ansible/roles/hermes/tasks/main.yml
+++ b/infra/ansible/roles/hermes/tasks/main.yml
@@ -254,20 +254,6 @@
     'apply_changed=true' in hermes_config_sync.stdout
   no_log: true
 
-- name: Check Hermes 1Password skill
-  ansible.builtin.stat:
-    path: "{{ hermes_home }}/skills/security/1password/SKILL.md"
-  register: hermes_1password_skill
-
-- name: Install Hermes 1Password skill
-  ansible.builtin.command:
-    cmd: "{{ hermes_venv_path }}/bin/hermes skills install official/security/1password --yes"
-  environment:
-    HERMES_HOME: "{{ hermes_home }}"
-    HOME: "{{ hermes_home }}"
-  when: not hermes_1password_skill.stat.exists
-  notify: Restart hermes-gateway
-
 - name: Allow Hermes service to manage skills
   ansible.builtin.file:
     path: "{{ hermes_config_dir }}/skills"
@@ -300,9 +286,10 @@
     follow: false
   when: hermes_op_config_file.stat.exists
 
-- name: Check Hermes config Newrrow skill and plugin
+- name: Check Hermes config required skills and plugins
   ansible.builtin.shell: |
     set -euo pipefail
+    test -f "{{ hermes_home }}/skills/security/1password/SKILL.md"
     test -f "{{ hermes_home }}/skills/newrrow-points-automation/SKILL.md"
     test -f "{{ hermes_home }}/skills/newrrow-points-automation/references/ui-flow.md"
     test -f "{{ hermes_home }}/plugins/newrrow-browser-login/plugin.yaml"

--- a/infra/ansible/roles/hermes/templates/hermes-config-apply.py.j2
+++ b/infra/ansible/roles/hermes/templates/hermes-config-apply.py.j2
@@ -22,6 +22,14 @@ SERVICE_GROUP = os.environ.get("HERMES_GROUP", "{{ hermes_group }}")
 VENV_PATH = Path(os.environ.get("HERMES_VENV_PATH", "{{ hermes_venv_path }}"))
 
 RESTART_PREFIXES = ("config/", "profiles/", "plugins/", "rules/", "kanban/", "cron/")
+HOMELAB_OWNED_DEFAULT_CONFIG_PATHS = (
+    ("auxiliary", "compression"),
+    ("browser",),
+    ("compression",),
+    ("platform_toolsets", "discord"),
+    ("plugins", "enabled"),
+    ("web",),
+)
 
 
 def uid_gid() -> tuple[int, int]:
@@ -53,6 +61,27 @@ def load_yaml(path: Path, fallback: Any = None) -> Any:
         return fallback
     data = yaml.safe_load(path.read_text(encoding="utf-8"))
     return fallback if data is None else data
+
+
+def path_exists(mapping: Any, path: tuple[str, ...]) -> bool:
+    current = mapping
+    for key in path:
+        if not isinstance(current, dict) or key not in current:
+            return False
+        current = current[key]
+    return True
+
+
+def reject_homelab_owned_default_config(desired: Any) -> None:
+    if not isinstance(desired, dict):
+        return
+    found = [".".join(path) for path in HOMELAB_OWNED_DEFAULT_CONFIG_PATHS if path_exists(desired, path)]
+    if found:
+        raise SystemExit(
+            "config/default/config.yaml contains homelab-owned runtime keys: "
+            + ", ".join(sorted(found))
+            + "; change these in holybaechu/homelab inventory/configure-runtime instead"
+        )
 
 
 def deep_merge(base: Any, desired: Any) -> Any:
@@ -154,6 +183,7 @@ def apply_default_config() -> tuple[bool, bool]:
     config_path = HERMES_HOME / "config.yaml"
     current = load_yaml(config_path, {})
     desired = load_yaml(desired_path, {})
+    reject_homelab_owned_default_config(desired)
     if not isinstance(current, dict) or not isinstance(desired, dict):
         raise SystemExit("Hermes config/default/config.yaml and live config.yaml must be YAML mappings")
     merged = deep_merge(current, desired)

--- a/infra/ansible/roles/hermes/templates/hermes-configure-runtime.py.j2
+++ b/infra/ansible/roles/hermes/templates/hermes-configure-runtime.py.j2
@@ -16,7 +16,7 @@ DESIRED_WEB_SEARCH_BACKEND = "{{ hermes_web_search_backend }}"
 DESIRED_WEB_EXTRACT_BACKEND = "{{ hermes_web_extract_backend }}"
 DESIRED_BROWSER_CLOUD_PROVIDER = "{{ hermes_browser_cloud_provider }}"
 DESIRED_BROWSER_AUTO_LOCAL_FOR_PRIVATE_URLS = {{ (hermes_browser_auto_local_for_private_urls | bool) | ternary('True', 'False') }}
-DESIRED_DISCORD_TOOLSETS = ["hermes-discord", "browser"]
+DESIRED_DISCORD_TOOLSETS = ["hermes-discord", "browser", "kanban"]
 DESIRED_PLUGINS = ["newrrow-browser-login"]
 SERVICE_USER = "{{ hermes_user }}"
 SERVICE_GROUP = "{{ hermes_group }}"
@@ -31,13 +31,11 @@ def ensure_dict(parent, key):
     return current
 
 
-def ensure_list(parent, key, default_items):
+def set_list(parent, key, desired_items):
     current = parent.get(key)
-    if isinstance(current, list):
-        return current
-    current = list(default_items)
-    parent[key] = current
-    return current
+    desired = list(desired_items)
+    parent[key] = desired
+    return current != desired
 
 
 def main():
@@ -100,27 +98,13 @@ def main():
         browser["auto_local_for_private_urls"] = DESIRED_BROWSER_AUTO_LOCAL_FOR_PRIVATE_URLS
         changed = True
 
-    discord_toolsets_existing = platform_toolsets.get("discord")
-    discord_toolsets = ensure_list(
+    changed |= set_list(
         platform_toolsets,
         "discord",
         DESIRED_DISCORD_TOOLSETS,
     )
-    if not isinstance(discord_toolsets_existing, list):
-        changed = True
-    for toolset in DESIRED_DISCORD_TOOLSETS:
-        if toolset not in discord_toolsets:
-            discord_toolsets.append(toolset)
-            changed = True
 
-    plugins_enabled_existing = plugins.get("enabled")
-    plugins_enabled = ensure_list(plugins, "enabled", DESIRED_PLUGINS)
-    if not isinstance(plugins_enabled_existing, list):
-        changed = True
-    for plugin in DESIRED_PLUGINS:
-        if plugin not in plugins_enabled:
-            plugins_enabled.append(plugin)
-            changed = True
+    changed |= set_list(plugins, "enabled", DESIRED_PLUGINS)
 
     if not changed:
         print("ok")

--- a/tests/hermes/test_hermes_edge_and_runbook.py
+++ b/tests/hermes/test_hermes_edge_and_runbook.py
@@ -108,9 +108,8 @@ def test_validate_playbook_checks_hermes_gateway_service_and_browser_cli():
     assert "hermes-config-webhook.service" in hermes_tasks
     assert "hermes-config-sync.timer" in hermes_tasks
     assert "readlink -f" in hermes_tasks
-    assert "newrrow-browser-login plugin is not enabled" in hermes_tasks
-    assert "discord platform" in hermes_tasks
-    assert "browser toolset" in hermes_tasks
+    assert "enabled plugins mismatch" in hermes_tasks
+    assert "discord platform toolsets mismatch" in hermes_tasks
     assert "chromium-" not in hermes_tasks
     assert "hermes-webui" not in hermes_tasks
     assert "hermes_webui_port" not in hermes_tasks
@@ -165,7 +164,7 @@ def test_hermes_runbook_documents_discord_gateway_web_search_browser_automation_
     assert "/var/lib/hermes/.agent-browser/browsers" in runbook
     assert "HOME=/var/lib/hermes" in runbook
     assert "1Password" in runbook
-    assert "official/security/1password" in runbook
+    assert "skills/security/1password" in runbook
     assert "op read" in runbook
     assert "op run" in runbook
     assert ".config/op" in runbook

--- a/tests/hermes/test_hermes_role.py
+++ b/tests/hermes/test_hermes_role.py
@@ -66,7 +66,7 @@ def test_hermes_role_installs_github_cli_for_workspace_tasks():
     assert "gh" in package_task["ansible.builtin.apt"]["name"]
 
 
-def test_hermes_role_installs_1password_cli_and_skill_for_secret_access():
+def test_hermes_role_installs_1password_cli_and_validates_live_config_skill_for_secret_access():
     tasks = read_yaml("infra/ansible/roles/hermes/tasks/main.yml")
 
     key_task = find_task(tasks, "Download 1Password apt signing key")
@@ -85,22 +85,14 @@ def test_hermes_role_installs_1password_cli_and_skill_for_secret_access():
     assert op_task["ansible.builtin.apt"]["name"] == "1password-cli"
     assert op_task["ansible.builtin.apt"]["update_cache"] is True
 
-    skill_check_task = find_task(tasks, "Check Hermes 1Password skill")
-    assert skill_check_task["ansible.builtin.stat"]["path"] == (
-        "{{ hermes_home }}/skills/security/1password/SKILL.md"
+    required_artifacts_task = find_task(tasks, "Check Hermes config required skills and plugins")
+    required_artifacts_shell = required_artifacts_task["ansible.builtin.shell"]
+    assert "{{ hermes_home }}/skills/security/1password/SKILL.md" in required_artifacts_shell
+    assert "{{ hermes_home }}/skills/newrrow-points-automation/SKILL.md" in required_artifacts_shell
+    assert "{{ hermes_home }}/plugins/newrrow-browser-login/plugin.yaml" in required_artifacts_shell
+    assert "hermes skills install official/security/1password" not in read(
+        "infra/ansible/roles/hermes/tasks/main.yml"
     )
-    assert skill_check_task["register"] == "hermes_1password_skill"
-
-    skill_task = find_task(tasks, "Install Hermes 1Password skill")
-    assert skill_task["ansible.builtin.command"]["cmd"] == (
-        "{{ hermes_venv_path }}/bin/hermes skills install official/security/1password --yes"
-    )
-    assert skill_task["environment"] == {
-        "HERMES_HOME": "{{ hermes_home }}",
-        "HOME": "{{ hermes_home }}",
-    }
-    assert skill_task["when"] == "not hermes_1password_skill.stat.exists"
-    assert skill_task["notify"] == "Restart hermes-gateway"
 
     ownership_task = find_task(tasks, "Allow Hermes service to manage skills")
     assert ownership_task["ansible.builtin.file"]["path"] == "{{ hermes_config_dir }}/skills"
@@ -139,8 +131,7 @@ def test_hermes_role_installs_1password_cli_and_skill_for_secret_access():
     repo_index = tasks.index(repo_task)
     op_index = tasks.index(op_task)
     agent_pip_index = tasks.index(find_task(tasks, "Install Hermes Agent messaging extras into virtualenv"))
-    skill_check_index = tasks.index(skill_check_task)
-    skill_index = tasks.index(skill_task)
+    required_artifacts_index = tasks.index(required_artifacts_task)
     ownership_index = tasks.index(ownership_task)
     op_config_index = tasks.index(op_config_task)
     op_config_file_check_index = tasks.index(op_config_file_check_task)
@@ -149,12 +140,11 @@ def test_hermes_role_installs_1password_cli_and_skill_for_secret_access():
     assert runtime_package_index < key_index < repo_index < op_index
     assert (
         agent_pip_index
-        < skill_check_index
-        < skill_index
         < ownership_index
         < op_config_index
         < op_config_file_check_index
         < op_config_file_index
+        < required_artifacts_index
         < service_index
     )
 
@@ -227,9 +217,10 @@ def test_hermes_role_wires_live_hermes_config_git_sync_with_restart_handler():
     assert "git_cmd config user.email \"$HERMES_CONFIG_COMMIT_USER_EMAIL\"" in sync_template
     assert "Hermes Config Bot" not in sync_template
     assert "hermes-config@hchu.me" not in sync_template
-    assert "migrate_to_symlink" in apply_template
-    assert "config/default/config.yaml" in apply_template
-    assert "plugins" in apply_template
+    assert "HOMELAB_OWNED_DEFAULT_CONFIG_PATHS" in apply_template
+    assert "reject_homelab_owned_default_config(desired)" in apply_template
+    assert '("platform_toolsets", "discord")' in apply_template
+    assert '("plugins", "enabled")' in apply_template
     assert "X-Hub-Signature-256" in webhook_template
     assert "hmac.compare_digest" in webhook_template
     assert "inotifywait" in watch_service
@@ -238,10 +229,10 @@ def test_hermes_role_wires_live_hermes_config_git_sync_with_restart_handler():
     assert "OnCalendar={{ hermes_config_sync_timer_schedule }}" in sync_timer
 
     sync_index = tasks.index(sync_task)
-    skill_check_index = tasks.index(find_task(tasks, "Check Hermes 1Password skill"))
+    required_artifacts_index = tasks.index(find_task(tasks, "Check Hermes config required skills and plugins"))
     service_index = tasks.index(find_task(tasks, "Enable Hermes config synchronization services"))
     gateway_index = tasks.index(find_task(tasks, "Enable Hermes gateway"))
-    assert sync_index < skill_check_index < service_index < gateway_index
+    assert sync_index < required_artifacts_index < service_index < gateway_index
 
 
 def test_hermes_role_uses_hermes_config_for_newrrow_skill_and_plugin():
@@ -265,7 +256,7 @@ def test_hermes_role_uses_hermes_config_for_newrrow_skill_and_plugin():
 
     assert "src: skills/newrrow-points-automation/" not in tasks_text
     assert "src: plugins/newrrow-browser-login/" not in tasks_text
-    assert "Check Hermes config Newrrow skill and plugin" in tasks_text
+    assert "Check Hermes config required skills and plugins" in tasks_text
     assert "{{ hermes_home }}/skills/newrrow-points-automation/SKILL.md" in tasks_text
     assert "{{ hermes_home }}/plugins/newrrow-browser-login/plugin.yaml" in tasks_text
 
@@ -276,7 +267,7 @@ def test_hermes_role_uses_hermes_config_for_newrrow_skill_and_plugin():
     assert login_helper_task["ansible.builtin.file"]["mode"] == "0755"
 
     sync_index = tasks.index(find_task(tasks, "Synchronize live Hermes config repository"))
-    check_index = tasks.index(find_task(tasks, "Check Hermes config Newrrow skill and plugin"))
+    check_index = tasks.index(find_task(tasks, "Check Hermes config required skills and plugins"))
     helper_index = tasks.index(login_helper_task)
     service_index = tasks.index(find_task(tasks, "Enable Hermes gateway"))
     assert sync_index < check_index < helper_index < service_index
@@ -484,10 +475,9 @@ def test_hermes_role_configures_browserbase_browser_automation():
     ) in script
     assert 'platform_toolsets = ensure_dict(config, "platform_toolsets")' in script
     assert 'plugins = ensure_dict(config, "plugins")' in script
-    assert 'DESIRED_DISCORD_TOOLSETS = ["hermes-discord", "browser"]' in script
+    assert 'DESIRED_DISCORD_TOOLSETS = ["hermes-discord", "browser", "kanban"]' in script
     assert 'DESIRED_PLUGINS = ["newrrow-browser-login"]' in script
-    assert "discord_toolsets = ensure_list" in script
-    assert "plugins_enabled = ensure_list" in script
+    assert "changed |= set_list" in script
     assert '"discord"' in script
 
     configure_task = find_task(tasks, "Configure Hermes runtime settings")


### PR DESCRIPTION
## Summary
- Make `homelab` the explicit owner of default-profile runtime config keys: `web.*`, `browser.*`, `compression.*`, `auxiliary.compression.*`, `plugins.enabled`, and `platform_toolsets.discord`.
- Reject those homelab-owned keys from `hermes-config/config/default/config.yaml` during live-config apply, so a remote config push cannot override IaC-owned runtime values.
- Remove the Ansible fallback that installed `official/security/1password` into the symlinked live skills tree; homelab now validates that `hermes-config` provides `skills/security/1password` and fails loudly if it is missing.
- Use exact allowlists for Discord toolsets and enabled plugins, including `kanban` in the default Discord toolset list.

## Test plan
- `python -m pytest -q` in homelab: `201 passed`
- Focused Hermes tests: `36 passed`
- Render/compile changed Hermes Python templates
- `git diff --check`
- Secret scan: `homelab-secret-scan-ok`

## Companion live-config change
- Pushed `holybaechu/hermes-config@973077c` (`fix: make homelab own runtime config keys`) removing `config/runtime-values.yaml`, removing the overlapping keys from `config/default/config.yaml`, and adding validator coverage.
