### PR TITLE
Fix Hermes config agent cron import

### DIFF
--- a/infra/ansible/roles/hermes/templates/hermes-config-apply.py.j2
+++ b/infra/ansible/roles/hermes/templates/hermes-config-apply.py.j2
@@ -295,21 +295,42 @@ def apply_cron_definitions() -> tuple[bool, bool]:
         deliver = job.get("deliver", "discord")
         desired_schedule = parse_schedule(schedule)
         existing = resolve_job_ref(name)
+        desired_skills = [str(item).strip() for item in (job.get("skills") or []) if str(item).strip()]
+        if not desired_skills and job.get("skill"):
+            desired_skills = [str(job["skill"]).strip()]
+        desired_toolsets = job.get("enabled_toolsets")
+        if desired_toolsets is not None:
+            desired_toolsets = [str(item).strip() for item in desired_toolsets if str(item).strip()]
+        desired_no_agent = bool(job.get("no_agent", False))
         if existing is None:
-            create_job(prompt=job.get("prompt", ""), schedule=schedule, name=name, deliver=deliver, script=script, no_agent=job.get("no_agent", True))
+            create_job(
+                prompt=job.get("prompt", ""),
+                schedule=schedule,
+                name=name,
+                deliver=deliver,
+                script=script,
+                no_agent=desired_no_agent,
+                skills=desired_skills,
+                enabled_toolsets=desired_toolsets,
+            )
             continue
         updates = {}
         if existing.get("schedule") != desired_schedule:
             updates["schedule"] = schedule
         if existing.get("schedule_display") != desired_schedule.get("display", schedule):
             updates["schedule_display"] = desired_schedule.get("display", schedule)
-        for key in ("prompt", "deliver", "script", "no_agent"):
-            desired = job.get(key, "" if key == "prompt" else True if key == "no_agent" else None)
-            if desired is not None and existing.get(key) != desired:
+        desired_fields = {
+            "prompt": job.get("prompt", ""),
+            "deliver": deliver,
+            "script": script,
+            "no_agent": desired_no_agent,
+            "skills": desired_skills,
+            "skill": desired_skills[0] if desired_skills else None,
+            "enabled_toolsets": desired_toolsets,
+        }
+        for key, desired in desired_fields.items():
+            if existing.get(key) != desired:
                 updates[key] = desired
-        if existing.get("skills") not in ([], None):
-            updates["skills"] = []
-            updates["skill"] = None
         if updates:
             update_job(existing["id"], updates)
     after = jobs_path.read_text(encoding="utf-8") if jobs_path.exists() else ""

--- a/tests/hermes/test_hermes_config_split.py
+++ b/tests/hermes/test_hermes_config_split.py
@@ -36,9 +36,25 @@ def test_homelab_hermes_config_declarative_state_has_no_local_drift():
     assert default_config["agent"]["max_turns"] == 1_000_000
     assert default_config["delegation"]["max_iterations"] == 1_000_000
 
-    cron_names = {
-        path.name: read_yaml(path).get("name")
+    cron_defs = {
+        path.name: read_yaml(path)
         for path in (HERMES_CONFIG_ROOT / "cron").glob("*.yaml")
     }
-    assert cron_names["homelab-kanban-daily-diagnostics.yaml"] == "homelab-kanban-daily-diagnostics"
-    assert cron_names["newrrow-daily-points.yaml"] == "Daily Newrrow points automation at 12:00 AM PDT"
+    assert cron_defs["homelab-kanban-daily-diagnostics.yaml"]["name"] == "homelab-kanban-daily-diagnostics"
+    newrrow_cron = cron_defs["newrrow-daily-points.yaml"]
+    assert newrrow_cron["name"] == "Daily Newrrow points automation at 12:00 AM PDT"
+    assert newrrow_cron["skills"] == ["newrrow-points-automation"]
+    assert newrrow_cron["enabled_toolsets"] == ["browser", "todo", "skills"]
+    assert newrrow_cron.get("no_agent") in (None, False)
+
+
+def test_hermes_config_apply_preserves_agent_cron_shape():
+    apply_template = (REPO_ROOT / "infra/ansible/roles/hermes/templates/hermes-config-apply.py.j2").read_text(encoding="utf-8")
+
+    assert 'desired_no_agent = bool(job.get("no_agent", False))' in apply_template
+    assert 'skills=desired_skills' in apply_template
+    assert 'enabled_toolsets=desired_toolsets' in apply_template
+    assert '"skills": desired_skills' in apply_template
+    assert '"enabled_toolsets": desired_toolsets' in apply_template
+    assert 'existing.get("skills") not in ([], None)' not in apply_template
+    assert 'job.get("no_agent", True)' not in apply_template


### PR DESCRIPTION
## Summary
- Preserve agent-mode cron definitions imported from `holybaechu/hermes-config`
- Stop defaulting cron YAML entries to `no_agent=true` unless explicitly requested
- Keep `skills` and `enabled_toolsets` for Newrrow daily points automation instead of clearing them during config apply

## Test Plan
- `.venv/bin/python -m pytest tests/hermes/test_hermes_config_split.py tests/hermes/test_hermes_role.py tests/hermes/test_hermes_edge_and_runbook.py -q`
- `.venv/bin/python -m pytest -q`
- `git diff --check`
