### PR TITLE
fix: preserve Honcho reasoning policy

### DIFF
--- a/infra/ansible/roles/hermes/templates/hermes-config-apply.py.j2
+++ b/infra/ansible/roles/hermes/templates/hermes-config-apply.py.j2
@@ -93,6 +93,15 @@ def deep_merge(base: Any, desired: Any) -> Any:
     return desired
 
 
+def contains_secret_key(value: Any) -> bool:
+    forbidden = {"apikey", "api_key", "token", "password", "secret"}
+    if isinstance(value, dict):
+        return any(str(key).lower() in forbidden or contains_secret_key(child) for key, child in value.items())
+    if isinstance(value, list):
+        return any(contains_secret_key(item) for item in value)
+    return False
+
+
 def atomic_write_text(path: Path, content: str, mode: int = 0o644) -> bool:
     path.parent.mkdir(parents=True, exist_ok=True)
     current = path.read_text(encoding="utf-8") if path.exists() else None
@@ -189,6 +198,32 @@ def apply_default_config() -> tuple[bool, bool]:
     merged = deep_merge(current, desired)
     rendered = yaml.safe_dump(merged, sort_keys=False, allow_unicode=True)
     changed = atomic_write_text(config_path, rendered, 0o600)
+    return changed, changed
+
+
+def apply_honcho_config() -> tuple[bool, bool]:
+    desired_path = CONFIG_DIR / "config/honcho.json"
+    if not desired_path.exists():
+        return False, False
+    live_path = HERMES_HOME / "honcho.json"
+    desired = json.loads(desired_path.read_text(encoding="utf-8"))
+    if not isinstance(desired, dict):
+        raise SystemExit("config/honcho.json must be a JSON object")
+    if contains_secret_key(desired):
+        raise SystemExit("config/honcho.json must contain only non-secret Honcho policy keys")
+    current = {}
+    if live_path.exists():
+        if live_path.is_symlink():
+            # Never keep Honcho credentials on a symlink into git-managed state.
+            current = json.loads(live_path.read_text(encoding="utf-8"))
+            live_path.unlink()
+        else:
+            current = json.loads(live_path.read_text(encoding="utf-8"))
+    if not isinstance(current, dict):
+        raise SystemExit("live honcho.json must be a JSON object")
+    merged = deep_merge(current, desired)
+    rendered = json.dumps(merged, indent=2, ensure_ascii=False) + "\n"
+    changed = atomic_write_text(live_path, rendered, 0o600)
     return changed, changed
 
 
@@ -354,6 +389,7 @@ def main() -> int:
 
     for func in (
         apply_default_config,
+        apply_honcho_config,
         apply_rules,
         apply_profiles,
         apply_kanban_policies,

--- a/tests/hermes/test_hermes_config_split.py
+++ b/tests/hermes/test_hermes_config_split.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 import yaml
 
@@ -36,6 +38,12 @@ def test_homelab_hermes_config_declarative_state_has_no_local_drift():
     assert default_config["agent"]["max_turns"] == 1_000_000
     assert default_config["delegation"]["max_iterations"] == 1_000_000
 
+    honcho_policy = json.loads((HERMES_CONFIG_ROOT / "config/honcho.json").read_text(encoding="utf-8"))
+    assert honcho_policy["dialecticReasoningLevel"] == "medium"
+    assert honcho_policy["dialecticDynamic"] is True
+    assert honcho_policy["reasoningLevelCap"] == "high"
+    assert honcho_policy["hosts"]["hermes_research"]["reasoningLevelCap"] == "max"
+
     cron_defs = {
         path.name: read_yaml(path)
         for path in (HERMES_CONFIG_ROOT / "cron").glob("*.yaml")
@@ -46,6 +54,20 @@ def test_homelab_hermes_config_declarative_state_has_no_local_drift():
     assert newrrow_cron["skills"] == ["newrrow-points-automation"]
     assert newrrow_cron["enabled_toolsets"] == ["browser", "todo", "skills"]
     assert newrrow_cron.get("no_agent") in (None, False)
+
+
+def test_hermes_config_apply_merges_non_secret_honcho_policy():
+    apply_template = (REPO_ROOT / "infra/ansible/roles/hermes/templates/hermes-config-apply.py.j2").read_text(encoding="utf-8")
+
+    assert "def apply_honcho_config()" in apply_template
+    assert 'CONFIG_DIR / "config/honcho.json"' in apply_template
+    assert 'HERMES_HOME / "honcho.json"' in apply_template
+    assert "contains_secret_key(desired)" in apply_template
+    assert "deep_merge(current, desired)" in apply_template
+    assert "live_path.is_symlink()" in apply_template
+    assert "Never keep Honcho credentials on a symlink into git-managed state" in apply_template
+    assert "apply_honcho_config," in apply_template
+    assert "live_path.symlink_to" not in apply_template
 
 
 def test_hermes_config_apply_preserves_agent_cron_shape():


### PR DESCRIPTION
## Summary
- Merge non-secret `hermes-config/config/honcho.json` policy into live `/var/lib/hermes/honcho.json`
- Preserve any existing live Honcho credentials while rejecting secret keys in the git-managed policy file
- Convert any accidental live `honcho.json` symlink into a real 0600 file so future Honcho setup cannot write credentials into git-managed state
- Add regression coverage for the Honcho reasoning policy and apply-path behavior

## Test Plan
- `/opt/hermes/venv/bin/python scripts/validate-hermes-config.py`
- `/var/lib/hermes/homelab/.venv/bin/python -m pytest -q` in `hermes-config`
- `/var/lib/hermes/homelab/.venv/bin/python -m pytest -q tests/hermes/test_hermes_config_split.py`
- Temp apply-script smoke test preserving dummy `apiKey` fields while applying the policy
- `/var/lib/hermes/homelab/.venv/bin/python -m pytest -q`
- `ANSIBLE_ROLES_PATH=infra/ansible/roles /var/lib/hermes/homelab/.venv/bin/ansible-playbook --syntax-check -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/site.yml`
- `ANSIBLE_ROLES_PATH=infra/ansible/roles /var/lib/hermes/homelab/.venv/bin/ansible-playbook --syntax-check -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/validate.yml`
