### PR TITLE
test: align Honcho research high cap

### DIFF
--- a/tests/hermes/test_hermes_config_split.py
+++ b/tests/hermes/test_hermes_config_split.py
@@ -42,7 +42,7 @@ def test_homelab_hermes_config_declarative_state_has_no_local_drift():
     assert honcho_policy["dialecticReasoningLevel"] == "medium"
     assert honcho_policy["dialecticDynamic"] is True
     assert honcho_policy["reasoningLevelCap"] == "high"
-    assert honcho_policy["hosts"]["hermes_research"]["reasoningLevelCap"] == "max"
+    assert honcho_policy["hosts"]["hermes_research"]["reasoningLevelCap"] == "high"
 
     cron_defs = {
         path.name: read_yaml(path)


### PR DESCRIPTION
## Summary
- Align homelab's Hermes config split regression test with the new Honcho research profile cap
- Research Honcho reasoning now caps at `high` instead of `max`, keeping depth 2 for deeper synthesis without $0.50/q max calls

## Test Plan
- `/var/lib/hermes/homelab/.venv/bin/python -m pytest -q tests/hermes/test_hermes_config_split.py`
- `/var/lib/hermes/homelab/.venv/bin/python -m pytest -q`
