### PR TITLE
chore: enable Honcho memory provider for Hermes

### DIFF
--- a/infra/ansible/inventory/prod/group_vars/svc_hermes.yml
+++ b/infra/ansible/inventory/prod/group_vars/svc_hermes.yml
@@ -48,10 +48,10 @@ hermes_browser_args: --no-sandbox,--disable-dev-shm-usage
 hermes_browserbase_proxies: false
 hermes_browserbase_advanced_stealth: false
 
-# Honcho memory stays disabled unless this is explicitly set to "honcho".
-# HONCHO_API_KEY is a runtime secret supplied through CI/Ansible extra-vars and
-# rendered only into /etc/hermes-gateway.env, never into hermes-config.
-hermes_memory_provider: ""
+# Honcho memory is enabled explicitly; HONCHO_API_KEY is a runtime secret
+# supplied through CI/Ansible extra-vars and rendered only into
+# /etc/hermes-gateway.env, never into hermes-config.
+hermes_memory_provider: "honcho"
 hermes_honcho_environment: production
 
 hermes_newrrow_username_ref: op://Hermes/Newrrow/username

--- a/tests/hermes/test_hermes_infra.py
+++ b/tests/hermes/test_hermes_infra.py
@@ -86,7 +86,7 @@ def test_hermes_group_vars_are_non_secret_service_settings():
     assert "hermes_browserbase_api_key:" not in group_vars
     assert "hermes_browserbase_project_id:" not in group_vars
     assert "hermes_honcho_api_key:" not in group_vars
-    assert "hermes_memory_provider: \"\"" in group_vars
+    assert "hermes_memory_provider: \"honcho\"" in group_vars
     assert "hermes_honcho_environment: production" in group_vars
     assert "hermes_config_repo: https://github.com/holybaechu/hermes-config.git" in group_vars
     assert "hermes_config_repo_token:" not in group_vars

--- a/tests/hermes/test_hermes_role.py
+++ b/tests/hermes/test_hermes_role.py
@@ -465,7 +465,7 @@ def test_hermes_role_gates_honcho_runtime_secret_and_memory_provider():
     script = read("infra/ansible/roles/hermes/templates/hermes-configure-runtime.py.j2")
     env_template = read("infra/ansible/roles/hermes/templates/hermes-gateway.env.j2")
 
-    assert group_vars["hermes_memory_provider"] == ""
+    assert group_vars["hermes_memory_provider"] == "honcho"
     assert group_vars["hermes_honcho_environment"] == "production"
     assert "hermes_honcho_api_key" not in group_vars
 


### PR DESCRIPTION
## Summary
- Enable `hermes_memory_provider: "honcho"` for the Hermes service
- Keep `HONCHO_API_KEY` as a runtime-only secret rendered into `/etc/hermes-gateway.env`
- Update Hermes role/config tests to expect Honcho as the managed provider

## Test Plan
- `HERMES_HOME=/var/lib/hermes /opt/hermes/venv/bin/hermes memory status` with gateway Honcho env: provider `honcho`, status `available`
- `honcho_profile`: returned successfully (`No profile facts available yet`)
- `/tmp/homelab-pytest-venv/bin/python -m pytest -q tests/hermes` → `42 passed`
- `git diff --check`
