### PR TITLE
chore(hermes): install media build packages

### DIFF
--- a/infra/ansible/roles/hermes/tasks/main.yml
+++ b/infra/ansible/roles/hermes/tasks/main.yml
@@ -51,12 +51,18 @@
       - bash
       - build-essential
       - ca-certificates
+      - cmake
       - curl
+      - ffmpeg
       - gh
       - git
       - inotify-tools
+      - libdrm-dev
+      - libva-dev
+      - ninja-build
       - nodejs
       - npm
+      - pkg-config
       - python3
       - python3-pip
       - python3-venv

--- a/tests/hermes/test_hermes_role.py
+++ b/tests/hermes/test_hermes_role.py
@@ -69,6 +69,21 @@ def test_hermes_role_installs_github_cli_for_workspace_tasks():
     assert "gh" in package_task["ansible.builtin.apt"]["name"]
 
 
+def test_hermes_role_installs_media_and_native_build_dependencies():
+    tasks = read_yaml("infra/ansible/roles/hermes/tasks/main.yml")
+
+    package_task = find_task(tasks, "Install Hermes runtime packages")
+    packages = set(package_task["ansible.builtin.apt"]["name"])
+    assert {
+        "pkg-config",
+        "ffmpeg",
+        "libva-dev",
+        "libdrm-dev",
+        "cmake",
+        "ninja-build",
+    }.issubset(packages)
+
+
 def test_hermes_role_installs_1password_cli_and_validates_live_config_skill_for_secret_access():
     tasks = read_yaml("infra/ansible/roles/hermes/tasks/main.yml")
 


### PR DESCRIPTION
## Summary
- Add Hermes runtime apt packages for native/media builds: `pkg-config`, `ffmpeg`, `cmake`, plus Debian package names `libva-dev`, `libdrm-dev`, and `ninja-build`
- Add regression coverage that the Hermes role keeps these packages in the runtime apt install task

## Test Plan
- `/tmp/homelab-pytest-venv/bin/python -m pytest -q tests/hermes/test_hermes_role.py`
- `/tmp/homelab-pytest-venv/bin/python -m pytest -q tests/hermes -k 'not declarative_state_has_no_local_drift'`
- `git diff --check`

## Notes
- Debian apt does not provide packages literally named `libva`, `libdrm`, or `ninja`; this uses the installable equivalents `libva-dev`, `libdrm-dev`, and `ninja-build` so headers/tooling are available for builds.
