### PR TITLE
fix: wait for lxc ssh during bootstrap

### DIFF
--- a/infra/ansible/playbooks/bootstrap.yml
+++ b/infra/ansible/playbooks/bootstrap.yml
@@ -55,6 +55,19 @@
       loop_control:
         label: "{{ item.item.name }}"
 
+    - name: Wait for LXC SSH ports to accept connections
+      ansible.builtin.wait_for:
+        host: "{{ hostvars[item.name].ansible_host }}"
+        port: 22
+        state: started
+        connect_timeout: 5
+        delay: 2
+        timeout: 180
+      delegate_to: localhost
+      loop: "{{ pve_lxc_access_bootstrap }}"
+      loop_control:
+        label: "{{ item.name }}"
+
 - name: Bootstrap Alpine LXCs
   hosts: alpine
   gather_facts: false

--- a/tests/infra/test_lxc_access_bootstrap.py
+++ b/tests/infra/test_lxc_access_bootstrap.py
@@ -45,6 +45,17 @@ def test_bootstrap_collects_lxc_host_keys_from_proxmox_instead_of_keyscan():
     assert "ansible.builtin.known_hosts" in playbook
 
 
+def test_bootstrap_waits_for_lxc_ssh_before_using_inventory_connections():
+    playbook = (REPO_ROOT / "infra" / "ansible" / "playbooks" / "bootstrap.yml").read_text(encoding="utf-8")
+
+    assert "Wait for LXC SSH ports to accept connections" in playbook
+    assert "ansible.builtin.wait_for" in playbook
+    assert 'host: "{{ hostvars[item.name].ansible_host }}"' in playbook
+    assert "port: 22" in playbook
+    assert "timeout: 180" in playbook
+    assert "delegate_to: localhost" in playbook
+
+
 def test_debian_lxc_bootstrap_checks_each_required_package():
     tasks = (
         REPO_ROOT


### PR DESCRIPTION
## Summary
- fixes the first-run CD bootstrap race for the newly-created `docker_apps` LXC
- waits for every bootstrapped LXC SSH port to accept connections before Ansible switches from Proxmox `pct exec` bootstrap to normal inventory SSH connections
- adds a regression test for the bootstrap wait gate

## CD failure addressed
The failed CD run reached the `Bootstrap Proxmox and LXC access` step and failed when `common_debian` tried to SSH to the new Docker apps host:

```text
fatal: [docker_apps]: UNREACHABLE
ssh: connect to host 192.168.0.10 port 22: Connection refused
```

The earlier `pct exec` bootstrap and host-key collection steps had succeeded, so the fix is to gate the transition to inventory SSH on TCP/22 readiness from the runner side.

## Verification
- `/var/lib/hermes/work/homelab-docker-compose-migration/.venv/bin/python -m pytest tests/infra/test_lxc_access_bootstrap.py -q`
  - `5 passed`
- `ANSIBLE_CONFIG=infra/ansible/ansible.cfg ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/bootstrap.yml --syntax-check`
  - passed
- isolated full pytest copy
  - `229 passed, 1 skipped`
- `PATH=".../.venv/bin:$PATH" ANSIBLE_CONFIG=infra/ansible/ansible.cfg ./scripts/ci/validate-compose.sh`
  - `100 passed`
  - Ansible site syntax passed
  - Docker Compose config validation skipped locally because Docker Compose is unavailable here
- `python3 scripts/ci/render_ansible_inventory.py --check && python3 scripts/ci/render_ansible_targets.py`
- `git diff --check`
