### PR TITLE
fix: allow slow lxc ssh readiness

### DIFF
--- a/infra/ansible/playbooks/bootstrap.yml
+++ b/infra/ansible/playbooks/bootstrap.yml
@@ -62,7 +62,7 @@
         state: started
         connect_timeout: 5
         delay: 2
-        timeout: 180
+        timeout: 600
       delegate_to: localhost
       loop: "{{ pve_lxc_access_bootstrap }}"
       loop_control:

--- a/tests/infra/test_lxc_access_bootstrap.py
+++ b/tests/infra/test_lxc_access_bootstrap.py
@@ -52,7 +52,7 @@ def test_bootstrap_waits_for_lxc_ssh_before_using_inventory_connections():
     assert "ansible.builtin.wait_for" in playbook
     assert 'host: "{{ hostvars[item.name].ansible_host }}"' in playbook
     assert "port: 22" in playbook
-    assert "timeout: 180" in playbook
+    assert "timeout: 600" in playbook
     assert "delegate_to: localhost" in playbook
 
 


### PR DESCRIPTION
## Summary
- increases the LXC SSH readiness gate from 180s to 600s before Ansible switches from Proxmox `pct exec` bootstrap to normal SSH inventory connections
- updates the bootstrap regression test

## Why
After #110, CD confirmed the new `docker_apps` LXC still had not accepted runner-side TCP/22 by the 180s readiness deadline:

```text
Timeout when waiting for 192.168.0.10:22
```

From the Hermes LXC shortly after the failed run, `192.168.0.10:22` was reachable, so this appears to be slow first-boot/network/SSH readiness rather than a permanently missing service. This keeps the readiness check but gives first-created Debian LXCs enough time to become reachable over the runner/Tailscale path.

## Verification
- `pytest tests/infra/test_lxc_access_bootstrap.py -q`
  - `5 passed`
- `ANSIBLE_CONFIG=infra/ansible/ansible.cfg ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/bootstrap.yml --syntax-check`
  - passed
- `git diff --check`
