### PR TITLE
feat: run adguard dns in docker compose

### DIFF
--- a/apps/compose/dns/.env.example
+++ b/apps/compose/dns/.env.example
@@ -1,0 +1,1 @@
+ADGUARD_IMAGE=adguard/adguardhome:v0.107.77

--- a/apps/compose/dns/README.md
+++ b/apps/compose/dns/README.md
@@ -1,0 +1,19 @@
+# DNS Compose project
+
+Runs AdGuard Home on the Docker apps host while the legacy `dns` LXC remains available for rollback during migration.
+
+## Ports
+
+- `53/tcp` and `53/udp` for plain DNS
+- `853/tcp` and `853/udp` for DNS-over-TLS / DNS-over-QUIC
+- Web UI is not published directly; Traefik proxies `adguard.home.hchu.me` to the container's internal port `3000` with the `private-only` middleware.
+
+## Managed state
+
+Ansible renders `/srv/docker-apps/adguard/conf/AdGuardHome.yaml` from the same Cloudflare/upstream policy used by the LXC role. Runtime work data lives under `/srv/docker-apps/adguard/work`.
+
+AdGuard TLS files for DoT/DoQ live under `/srv/docker-apps/adguard/tls` and are renewed by a host-side systemd timer using the existing Cloudflare DNS-01 token.
+
+## Policy
+
+Do not add a public `dns.hchu.me` DoH route. AdGuard should keep `adguard.home.hchu.me` as its TLS/certificate server name and Cloudflare DNS (`tls://1.1.1.1`, `tls://1.0.0.1`) as upstreams.

--- a/apps/compose/dns/compose.yml
+++ b/apps/compose/dns/compose.yml
@@ -1,0 +1,30 @@
+name: dns
+
+services:
+  adguard:
+    image: ${ADGUARD_IMAGE:-adguard/adguardhome:v0.107.77}
+    restart: unless-stopped
+    ports:
+      - "53:53/tcp"
+      - "53:53/udp"
+      - "853:853/tcp"
+      - "853:853/udp"
+    volumes:
+      - /srv/docker-apps/adguard/work:/opt/adguardhome/work:rw
+      - /srv/docker-apps/adguard/conf:/opt/adguardhome/conf:rw
+      - /srv/docker-apps/adguard/tls:/opt/adguardhome/tls:ro
+    networks:
+      - proxy
+    labels:
+      - traefik.enable=true
+      - traefik.docker.network=homelab_proxy
+      - traefik.http.routers.adguard.rule=Host(`adguard.home.hchu.me`)
+      - traefik.http.routers.adguard.entrypoints=websecure
+      - traefik.http.routers.adguard.tls.certresolver=cloudflare
+      - traefik.http.routers.adguard.middlewares=private-only@file,secure-headers@file
+      - traefik.http.services.adguard.loadbalancer.server.port=3000
+
+networks:
+  proxy:
+    external: true
+    name: homelab_proxy

--- a/apps/compose/traefik/dynamic.yml
+++ b/apps/compose/traefik/dynamic.yml
@@ -36,13 +36,6 @@ http:
         certResolver: cloudflare
       middlewares: [secure-headers]
       service: hermes-config-webhook
-    adguard:
-      rule: Host(`adguard.home.hchu.me`)
-      entryPoints: [websecure]
-      tls:
-        certResolver: cloudflare
-      middlewares: [private-only, secure-headers]
-      service: adguard
     pve:
       rule: Host(`pve.home.hchu.me`)
       entryPoints: [websecure]
@@ -63,11 +56,6 @@ http:
       loadBalancer:
         servers:
           - url: http://192.168.0.9:8787
-    adguard:
-      loadBalancer:
-        serversTransport: adguard-transport
-        servers:
-          - url: https://192.168.0.3:443
     pve:
       loadBalancer:
         serversTransport: pve-transport
@@ -79,8 +67,6 @@ http:
           - url: http://192.168.0.1
 
   serversTransports:
-    adguard-transport:
-      serverName: adguard.home.hchu.me
     pve-transport:
       serverName: pve.home.hchu.me
       rootCAs:

--- a/apps/dns/acme/renew-adguard-cert.sh
+++ b/apps/dns/acme/renew-adguard-cert.sh
@@ -34,7 +34,9 @@ chown root:"${TLS_GROUP}" "${CERT_DIR}" "${CERT_DIR}/fullchain.pem" "${CERT_DIR}
 chmod 0750 "${CERT_DIR}"
 chmod 0640 "${CERT_DIR}/fullchain.pem" "${CERT_DIR}/privkey.pem"
 
-if [ -x /etc/init.d/adguardhome ]; then
+if [ -n "${ADGUARD_RESTART_COMMAND:-}" ]; then
+  sh -c "${ADGUARD_RESTART_COMMAND}" || echo "AdGuard restart command failed; certificate staged"
+elif [ -x /etc/init.d/adguardhome ]; then
   rc-service adguardhome restart
   rc-service adguardhome status
 else

--- a/docs/runbooks/docker-compose-migration.md
+++ b/docs/runbooks/docker-compose-migration.md
@@ -5,10 +5,9 @@ host while keeping network and control planes independent.
 
 ## Target split
 
-- `docker_apps` LXC: Traefik, gluetun, qBittorrent, Copyparty, and Minecraft.
+- `docker_apps` LXC: Traefik, AdGuard Home, gluetun, qBittorrent, Copyparty, and Minecraft.
 - `tailnet` LXC: Tailscale subnet router / exit node.
 - `hermes` LXC: Hermes gateway, Kanban dispatcher, skills/memory/profile/cron state, and recovery tooling.
-- `dns` LXC: AdGuard remains separate during the first migration phase.
 
 ## Why Tailnet stays outside Docker
 
@@ -31,13 +30,16 @@ explicitly accepts that root-equivalent trust boundary.
 ## Cutover guardrails
 
 1. Deploy `docker_apps` without removing old LXCs.
-2. Keep Caddy/edge running as rollback until Traefik route parity is proven.
+2. Keep Caddy/edge and the old AdGuard `dns` LXC running as rollback until
+   Traefik and Docker AdGuard route/parity are proven.
 3. Keep old qBittorrent, Copyparty, and Minecraft LXCs stopped but recoverable
    during soak.
 4. Do not expose public `dns.hchu.me` DoH.
-5. Keep qBittorrent `/public` read-write so seeded public content remains
+5. Keep AdGuard's TLS/certificate server name as `adguard.home.hchu.me` and keep
+   Cloudflare DNS (`tls://1.1.1.1`, `tls://1.0.0.1`) as upstream policy.
+6. Keep qBittorrent `/public` read-write so seeded public content remains
    available through Copyparty.
-6. Keep Copyparty plaintext `password` entries in `COPYPARTY_USERS_JSON` unless
+7. Keep Copyparty plaintext `password` entries in `COPYPARTY_USERS_JSON` unless
    password hashing is explicitly requested.
 
 ## Validation
@@ -56,12 +58,16 @@ After deployment but before cutover:
 ```bash
 ssh root@192.168.0.10 'docker ps'
 ssh root@192.168.0.10 'cd /opt/homelab-compose/traefik && docker compose ps'
+ssh root@192.168.0.10 'cd /opt/homelab-compose/dns && docker compose ps'
 ssh root@192.168.0.10 'cd /opt/homelab-compose/media && docker compose ps'
 ssh root@192.168.0.10 'cd /opt/homelab-compose/game && docker compose ps'
+ssh root@192.168.0.10 'dig @127.0.0.1 example.com'
+ssh root@192.168.0.10 'openssl s_client -connect 127.0.0.1:853 -servername adguard.home.hchu.me </dev/null'
 ```
 
 ## Rollback
 
+- DNS rollback: keep clients/router pointed at the old `dns` LXC (`192.168.0.3`) until Docker AdGuard is proven. If Docker DNS fails after cutover, restore the old DNS IP target first, then stop the `dns` Compose project.
 - Edge rollback: restore router/DNS forwarding to `192.168.0.4` and keep Traefik
   stopped.
 - Media rollback: stop the media Compose project and restart old `downloads` and

--- a/infra/ansible/inventory/prod/group_vars/svc_docker_apps.yml
+++ b/infra/ansible/inventory/prod/group_vars/svc_docker_apps.yml
@@ -15,6 +15,39 @@ traefik_private_domain: home.hchu.me
 traefik_proxy_network: homelab_proxy
 copyparty_listen_port: 3923
 
+adguard_image: adguard/adguardhome:v0.107.77
+adguard_admin_port: 3000
+adguard_dns_port: 53
+adguard_https_port: 443
+adguard_dot_port: 853
+adguard_cert_domain: adguard.home.hchu.me
+adguard_host_work_dir: "{{ docker_apps_data_root }}/adguard/work"
+adguard_host_conf_dir: "{{ docker_apps_data_root }}/adguard/conf"
+adguard_host_tls_dir: "{{ docker_apps_data_root }}/adguard/tls"
+adguard_host_lego_path: "{{ docker_apps_data_root }}/adguard/lego"
+adguard_acme_env_path: /etc/homelab/adguard-acme.env
+adguard_container_tls_dir: /opt/adguardhome/tls
+adguard_acme_interval_seconds: 43200
+adguard_upstream_dns:
+  - tls://1.1.1.1
+  - tls://1.0.0.1
+adguard_bootstrap_dns:
+  - 1.1.1.1
+  - 1.0.0.1
+adguard_fallback_dns:
+  - 1.1.1.1
+  - 1.0.0.1
+adguard_trusted_proxies:
+  - 127.0.0.0/8
+  - ::1/128
+  - 172.16.0.0/12
+  - "{{ docker_apps_ip }}/32"
+adguard_dns_filters:
+  - enabled: true
+    url: https://adguardteam.github.io/HostlistsRegistry/assets/filter_48.txt
+    name: HaGeZi's Pro Blocklist
+    id: 48
+
 # Compose projects are copied from the tracked repo and receive host-rendered
 # .env files from templates under roles/docker_compose_project/templates/.
 docker_compose_projects:
@@ -22,6 +55,12 @@ docker_compose_projects:
     src: apps/compose/traefik
     dest: "{{ docker_apps_compose_root }}/traefik"
     env_template: traefik.env.j2
+  - name: dns
+    src: apps/compose/dns
+    dest: "{{ docker_apps_compose_root }}/dns"
+    env_template: dns.env.j2
+    adguard_config_template: adguardhome.yaml.j2
+    adguard_acme: true
   - name: media
     src: apps/compose/media
     dest: "{{ docker_apps_compose_root }}/media"

--- a/infra/ansible/playbooks/bootstrap.yml
+++ b/infra/ansible/playbooks/bootstrap.yml
@@ -62,7 +62,7 @@
         state: started
         connect_timeout: 5
         delay: 2
-        timeout: 180
+        timeout: 600
       delegate_to: localhost
       loop: "{{ pve_lxc_access_bootstrap }}"
       loop_control:

--- a/infra/ansible/playbooks/validate.yml
+++ b/infra/ansible/playbooks/validate.yml
@@ -263,6 +263,9 @@
           traefik)
             expected="traefik"
             ;;
+          dns)
+            expected="adguard"
+            ;;
           media)
             expected="gluetun qbittorrent copyparty"
             ;;
@@ -283,6 +286,18 @@
       loop_control:
         label: "{{ item.name }}"
       changed_when: false
+
+    - name: Check Docker AdGuard DNS TCP port
+      ansible.builtin.wait_for:
+        host: 127.0.0.1
+        port: "{{ adguard_dns_port }}"
+        timeout: 10
+
+    - name: Check Docker AdGuard DNS-over-TLS TCP port
+      ansible.builtin.wait_for:
+        host: 127.0.0.1
+        port: "{{ adguard_dot_port }}"
+        timeout: 10
 
 - name: Validate hermes
   hosts: svc_hermes

--- a/infra/ansible/roles/docker_compose_project/tasks/main.yml
+++ b/infra/ansible/roles/docker_compose_project/tasks/main.yml
@@ -18,6 +18,121 @@
   loop_control:
     label: "{{ item.name }}"
 
+- name: Install Compose project helper packages
+  ansible.builtin.apt:
+    name:
+      - apache2-utils
+      - dnsutils
+      - lego
+      - openssl
+    state: present
+    update_cache: true
+
+- name: Create AdGuard host state directories
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "{{ item.mode }}"
+  loop:
+    - path: /etc/homelab
+      mode: "0700"
+    - path: "{{ adguard_host_work_dir }}"
+      mode: "0750"
+    - path: "{{ adguard_host_conf_dir }}"
+      mode: "0750"
+    - path: "{{ adguard_host_tls_dir }}"
+      mode: "0750"
+    - path: "{{ adguard_host_lego_path }}"
+      mode: "0700"
+  loop_control:
+    label: "{{ item.path }}"
+
+- name: Require Docker AdGuard admin credentials
+  ansible.builtin.assert:
+    that:
+      - adguard_admin_username is defined
+      - adguard_admin_username | length > 0
+      - adguard_admin_username is match('^[A-Za-z0-9_.-]+$')
+      - adguard_admin_password is defined
+      - adguard_admin_password | length > 0
+    fail_msg: adguard_admin_username and adguard_admin_password must be provided for Docker AdGuard config rendering.
+  no_log: true
+
+- name: Read existing Docker AdGuard admin password hash
+  ansible.builtin.command:
+    argv:
+      - python3
+      - -c
+      - |
+        from pathlib import Path
+        import sys
+
+        path = Path(sys.argv[1])
+        username = sys.argv[2]
+        if not path.exists():
+            print("")
+            raise SystemExit(0)
+
+        lines = path.read_text(encoding="utf-8").splitlines()
+        for index, line in enumerate(lines):
+            if line.strip() == f'- name: "{username}"':
+                for candidate in lines[index + 1 : index + 4]:
+                    stripped = candidate.strip()
+                    if stripped.startswith("password:"):
+                        print(stripped.split(":", 1)[1].strip().strip('"'))
+                        raise SystemExit(0)
+        print("")
+      - "{{ adguard_host_conf_dir }}/AdGuardHome.yaml"
+      - "{{ adguard_admin_username }}"
+  register: docker_adguard_existing_admin_hash
+  changed_when: false
+  no_log: true
+
+- name: Verify existing Docker AdGuard admin password hash
+  ansible.builtin.shell: |
+    set -eu
+    tmp="$(mktemp)"
+    trap 'rm -f "${tmp}"' EXIT
+    printf '%s:%s\n' "${ADGUARD_ADMIN_USERNAME}" "${ADGUARD_ADMIN_HASH}" > "${tmp}"
+    htpasswd -vb "${tmp}" "${ADGUARD_ADMIN_USERNAME}" "${ADGUARD_ADMIN_PASSWORD}" >/dev/null
+  args:
+    executable: /bin/sh
+  environment:
+    ADGUARD_ADMIN_USERNAME: "{{ adguard_admin_username }}"
+    ADGUARD_ADMIN_HASH: "{{ docker_adguard_existing_admin_hash.stdout }}"
+    ADGUARD_ADMIN_PASSWORD: "{{ adguard_admin_password }}"
+  register: docker_adguard_existing_admin_hash_verify
+  changed_when: false
+  failed_when: false
+  no_log: true
+  when: docker_adguard_existing_admin_hash.stdout | length > 0
+
+- name: Hash Docker AdGuard admin password when rotation is required
+  ansible.builtin.command:
+    argv:
+      - htpasswd
+      - -B
+      - -C
+      - "10"
+      - -n
+      - -b
+      - "{{ adguard_admin_username }}"
+      - "{{ adguard_admin_password }}"
+  register: docker_adguard_admin_htpasswd
+  changed_when: false
+  no_log: true
+  when: docker_adguard_existing_admin_hash_verify.rc | default(1) != 0
+
+- name: Set Docker AdGuard admin password hash
+  ansible.builtin.set_fact:
+    adguard_admin_password_hash: >-
+      {{ docker_adguard_existing_admin_hash.stdout
+      if (docker_adguard_existing_admin_hash_verify.rc | default(1)) == 0
+      else docker_adguard_admin_htpasswd.stdout.split(':', 1)[1] }}
+  no_log: true
+
 - name: Copy tracked Compose project files
   ansible.builtin.copy:
     src: "{{ playbook_dir }}/../../../{{ item.src }}/"
@@ -57,6 +172,87 @@
   when: item.copyparty_config_template is defined
   no_log: true
   notify: Restart Compose project
+
+- name: Render Docker AdGuard config
+  ansible.builtin.template:
+    src: "{{ item.adguard_config_template }}"
+    dest: "{{ adguard_host_conf_dir }}/AdGuardHome.yaml"
+    owner: root
+    group: root
+    mode: "0600"
+  loop: "{{ docker_compose_projects }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when: item.adguard_config_template is defined
+  no_log: true
+  notify: Restart Compose project
+
+- name: Install AdGuard ACME renewal script for Docker DNS
+  ansible.builtin.copy:
+    src: "{{ playbook_dir }}/../../../apps/dns/acme/renew-adguard-cert.sh"
+    dest: /usr/local/bin/renew-adguard-cert
+    owner: root
+    group: root
+    mode: "0700"
+
+- name: Render AdGuard ACME environment file
+  ansible.builtin.copy:
+    dest: "{{ adguard_acme_env_path }}"
+    owner: root
+    group: root
+    mode: "0600"
+    content: |
+      CLOUDFLARE_ADGUARD_ACME_TOKEN={{ cloudflare_adguard_acme_token | quote }}
+      ADGUARD_CERT_DOMAIN={{ adguard_cert_domain | quote }}
+      ADGUARD_TLS_DIR={{ adguard_host_tls_dir | quote }}
+      ADGUARD_TLS_GROUP=root
+      LEGO_PATH={{ adguard_host_lego_path | quote }}
+      ACME_EMAIL={{ traefik_acme_email | quote }}
+      ADGUARD_RESTART_COMMAND={{ ('cd ' ~ docker_apps_compose_root ~ '/dns && docker compose restart adguard') | quote }}
+  no_log: true
+
+- name: Install AdGuard ACME systemd unit
+  ansible.builtin.template:
+    src: adguard-acme.service.j2
+    dest: /etc/systemd/system/adguard-acme.service
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Install AdGuard ACME systemd timer
+  ansible.builtin.template:
+    src: adguard-acme.timer.j2
+    dest: /etc/systemd/system/adguard-acme.timer
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Stat Docker AdGuard TLS files
+  ansible.builtin.stat:
+    path: "{{ adguard_host_tls_dir }}/{{ item }}"
+  loop:
+    - fullchain.pem
+    - privkey.pem
+  register: docker_adguard_tls_files
+
+- name: Issue initial Docker AdGuard certificate when missing
+  ansible.builtin.shell: |
+    set -eu
+    set -a
+    . "{{ adguard_acme_env_path }}"
+    set +a
+    /usr/local/bin/renew-adguard-cert
+  args:
+    executable: /bin/sh
+  no_log: true
+  when: docker_adguard_tls_files.results | selectattr('stat.exists', 'equalto', false) | list | length > 0
+
+- name: Enable AdGuard ACME timer
+  ansible.builtin.systemd:
+    name: adguard-acme.timer
+    enabled: true
+    state: started
+    daemon_reload: true
 
 - name: Pull Compose project images
   ansible.builtin.command:

--- a/infra/ansible/roles/docker_compose_project/templates/adguard-acme.service.j2
+++ b/infra/ansible/roles/docker_compose_project/templates/adguard-acme.service.j2
@@ -1,0 +1,9 @@
+[Unit]
+Description=Renew AdGuard Home certificate for Docker Compose DNS
+After=network-online.target docker.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+EnvironmentFile={{ adguard_acme_env_path }}
+ExecStart=/usr/local/bin/renew-adguard-cert

--- a/infra/ansible/roles/docker_compose_project/templates/adguard-acme.timer.j2
+++ b/infra/ansible/roles/docker_compose_project/templates/adguard-acme.timer.j2
@@ -1,0 +1,11 @@
+[Unit]
+Description=Renew AdGuard Home certificate for Docker Compose DNS periodically
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec={{ adguard_acme_interval_seconds }}s
+Persistent=true
+Unit=adguard-acme.service
+
+[Install]
+WantedBy=timers.target

--- a/infra/ansible/roles/docker_compose_project/templates/adguardhome.yaml.j2
+++ b/infra/ansible/roles/docker_compose_project/templates/adguardhome.yaml.j2
@@ -1,0 +1,110 @@
+schema_version: 34
+users:
+  - name: "{{ adguard_admin_username }}"
+    password: "{{ adguard_admin_password_hash }}"
+auth_attempts: 5
+block_auth_min: 15
+http:
+  address: 0.0.0.0:{{ adguard_admin_port }}
+  pprof:
+    enabled: false
+    port: 6060
+  session_ttl: 720h
+  doh:
+    routes:
+      - GET /dns-query
+      - POST /dns-query
+      - GET /dns-query/{ClientID}
+      - POST /dns-query/{ClientID}
+http_proxy: ""
+language: en
+theme: auto
+clients:
+  runtime_sources:
+    whois: true
+    arp: true
+    rdns: false
+    dhcp: true
+    hosts: true
+  persistent: []
+dns:
+  bind_hosts:
+    - 0.0.0.0
+  port: {{ adguard_dns_port }}
+  anonymize_client_ip: false
+  ratelimit: 20
+  upstream_dns:
+{% for upstream in adguard_upstream_dns %}
+    - {{ upstream }}
+{% endfor %}
+  bootstrap_dns:
+{% for bootstrap in adguard_bootstrap_dns %}
+    - {{ bootstrap }}
+{% endfor %}
+  fallback_dns:
+{% for fallback in adguard_fallback_dns %}
+    - {{ fallback }}
+{% endfor %}
+  upstream_mode: load_balance
+  cache_optimistic_answer_ttl: 30s
+  cache_optimistic_max_age: 12h
+  edns_client_subnet:
+    custom_ip: ""
+    enabled: false
+    use_custom: false
+  trusted_proxies:
+{% for proxy in adguard_trusted_proxies %}
+    - {{ proxy }}
+{% endfor %}
+filtering:
+  protection_enabled: true
+  rewrites_enabled: true
+  rewrites:
+    - domain: '*.{{ homelab_private_domain }}'
+      answer: {{ docker_apps_ip }}
+      enabled: true
+  blocked_services:
+    schedule:
+      time_zone: Local
+  safe_fs_patterns:
+    - /opt/adguardhome/work/data/userfilters/*
+  safe_search:
+    bing: true
+    duckduckgo: true
+    enabled: true
+    google: true
+    pixabay: true
+    yandex: true
+    youtube: true
+querylog:
+  enabled: true
+  file_enabled: true
+  ignored: []
+  ignored_enabled: false
+  interval: 90d
+  size_memory: 1000
+statistics:
+  enabled: true
+  ignored: []
+  ignored_enabled: false
+  interval: 1d
+tls:
+  enabled: true
+  server_name: {{ adguard_cert_domain }}
+  force_https: false
+  port_https: {{ adguard_https_port }}
+  port_dns_over_tls: {{ adguard_dot_port }}
+  port_dns_over_quic: {{ adguard_dot_port }}
+  certificate_path: {{ adguard_container_tls_dir }}/fullchain.pem
+  private_key_path: {{ adguard_container_tls_dir }}/privkey.pem
+filters:
+{% for dns_filter in adguard_dns_filters %}
+  - enabled: {{ dns_filter.enabled | lower }}
+    url: {{ dns_filter.url }}
+    name: "{{ dns_filter.name }}"
+    id: {{ dns_filter.id }}
+{% endfor %}
+os:
+  group: ""
+  rlimit_nofile: 0
+  user: ""

--- a/infra/ansible/roles/docker_compose_project/templates/dns.env.j2
+++ b/infra/ansible/roles/docker_compose_project/templates/dns.env.j2
@@ -1,0 +1,1 @@
+ADGUARD_IMAGE={{ adguard_image }}

--- a/infra/ansible/roles/pve_homelab_storage/tasks/main.yml
+++ b/infra/ansible/roles/pve_homelab_storage/tasks/main.yml
@@ -54,6 +54,10 @@
       "${mount_path}/copyparty/shared-readonly" \
       "${mount_path}/copyparty/downloads" \
       "${mount_path}/docker-apps/traefik" \
+      "${mount_path}/docker-apps/adguard/work" \
+      "${mount_path}/docker-apps/adguard/conf" \
+      "${mount_path}/docker-apps/adguard/tls" \
+      "${mount_path}/docker-apps/adguard/lego" \
       "${mount_path}/docker-apps/qbittorrent" \
       "${mount_path}/docker-apps/gluetun" \
       "${mount_path}/docker-apps/copyparty" \
@@ -68,7 +72,7 @@
       chown -R {{ homelab_container_uid_offset + docker_apps_service_uid }}:{{ homelab_container_uid_offset + docker_apps_service_gid }} "${mount_path}/docker-apps" "${mount_path}/minecraft"
       chmod 0755 "${mount_path}" "${mount_path}/downloads" "${mount_path}/downloads/complete" "${mount_path}/downloads/incomplete" "${mount_path}/copyparty"
       chmod 0755 "${mount_path}/copyparty/public" "${mount_path}/copyparty/shared-readonly" "${mount_path}/copyparty/downloads"
-      chmod 0755 "${mount_path}/docker-apps" "${mount_path}/docker-apps/traefik" "${mount_path}/docker-apps/qbittorrent" "${mount_path}/docker-apps/gluetun" "${mount_path}/docker-apps/copyparty" "${mount_path}/minecraft"
+      chmod 0755 "${mount_path}/docker-apps" "${mount_path}/docker-apps/traefik" "${mount_path}/docker-apps/adguard" "${mount_path}/docker-apps/adguard/work" "${mount_path}/docker-apps/adguard/conf" "${mount_path}/docker-apps/adguard/tls" "${mount_path}/docker-apps/adguard/lego" "${mount_path}/docker-apps/qbittorrent" "${mount_path}/docker-apps/gluetun" "${mount_path}/docker-apps/copyparty" "${mount_path}/minecraft"
       chmod 0755 "${mount_path}/hermes" "${mount_path}/hermes/home" "${mount_path}/hermes/workspace"
       find "${mount_path}/copyparty/public" -type d -exec chmod 0755 {} +
       find "${mount_path}/copyparty/public" -type f -exec chmod 0644 {} +

--- a/tests/docker/test_compose_secrets.py
+++ b/tests/docker/test_compose_secrets.py
@@ -32,12 +32,21 @@ def test_compose_files_do_not_contain_raw_secret_material():
 
 def test_env_templates_are_rendered_by_ansible_not_committed_as_real_envs():
     template_dir = REPO_ROOT / "infra" / "ansible" / "roles" / "docker_compose_project" / "templates"
-    for name in ("traefik.env.j2", "media.env.j2", "game.env.j2", "copyparty.conf.j2"):
+    for name in (
+        "traefik.env.j2",
+        "media.env.j2",
+        "game.env.j2",
+        "dns.env.j2",
+        "copyparty.conf.j2",
+        "adguardhome.yaml.j2",
+    ):
         assert (template_dir / name).exists()
 
     media = (template_dir / "media.env.j2").read_text(encoding="utf-8")
     copyparty = (template_dir / "copyparty.conf.j2").read_text(encoding="utf-8")
+    adguard = (template_dir / "adguardhome.yaml.j2").read_text(encoding="utf-8")
     assert "{{ proton_wireguard_private_key" in media
     assert "{{ copyparty_users" in media
     assert "{% for user in copyparty_users %}" in copyparty
     assert "{{ user.name }}: {{ user.password }}" in copyparty
+    assert "{{ adguard_admin_password_hash }}" in adguard

--- a/tests/docker/test_dns_compose.py
+++ b/tests/docker/test_dns_compose.py
@@ -1,0 +1,41 @@
+from tests.helpers import REPO_ROOT
+
+
+def _read(path: str) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def test_dns_compose_runs_adguard_and_exposes_dns_ports():
+    compose = _read("apps/compose/dns/compose.yml")
+
+    assert "adguard/adguardhome" in compose
+    assert '"53:53/tcp"' in compose
+    assert '"53:53/udp"' in compose
+    assert '"853:853/tcp"' in compose
+    assert '"853:853/udp"' in compose
+    assert "/srv/docker-apps/adguard/work:/opt/adguardhome/work:rw" in compose
+    assert "/srv/docker-apps/adguard/conf:/opt/adguardhome/conf:rw" in compose
+    assert "/srv/docker-apps/adguard/tls:/opt/adguardhome/tls:ro" in compose
+
+
+def test_dns_compose_routes_adguard_ui_privately_through_traefik():
+    compose = _read("apps/compose/dns/compose.yml")
+
+    assert "traefik.http.routers.adguard.rule=Host(`adguard.home.hchu.me`)" in compose
+    assert "private-only@file,secure-headers@file" in compose
+    assert "traefik.http.services.adguard.loadbalancer.server.port=3000" in compose
+    assert "dns.hchu.me" not in compose
+    assert "dns-query" not in compose
+
+
+def test_docker_adguard_template_preserves_dns_policy_and_tls_name():
+    template = _read("infra/ansible/roles/docker_compose_project/templates/adguardhome.yaml.j2")
+    vars_file = _read("infra/ansible/inventory/prod/group_vars/svc_docker_apps.yml")
+
+    assert "server_name: {{ adguard_cert_domain }}" in template
+    assert "certificate_path: {{ adguard_container_tls_dir }}/fullchain.pem" in template
+    assert "answer: {{ docker_apps_ip }}" in template
+    assert "tls://1.1.1.1" in vars_file
+    assert "tls://1.0.0.1" in vars_file
+    assert "adguard_cert_domain: adguard.home.hchu.me" in vars_file
+    assert "dns.hchu.me" not in template

--- a/tests/docker/test_docker_apps_validate_playbook.py
+++ b/tests/docker/test_docker_apps_validate_playbook.py
@@ -10,5 +10,8 @@ def test_validate_playbook_checks_docker_apps_compose_projects():
     assert "docker network inspect {{ traefik_proxy_network }}" in validate
     assert "docker compose config" in validate
     assert "docker compose ps --services" in validate
+    assert "expected=\"adguard\"" in validate
     assert "gluetun qbittorrent copyparty" in validate
     assert "paper velocity" in validate
+    assert "Check Docker AdGuard DNS TCP port" in validate
+    assert "Check Docker AdGuard DNS-over-TLS TCP port" in validate

--- a/tests/docker/test_docker_compose_project_role.py
+++ b/tests/docker/test_docker_compose_project_role.py
@@ -13,6 +13,15 @@ def test_compose_project_role_renders_secret_envs_and_uses_remove_orphans():
     assert "docker compose up -d --remove-orphans" in tasks
     assert "copyparty_config_template" in tasks
     assert "Render media Copyparty config with plaintext password accounts" in tasks
+    assert "adguard_config_template" in tasks
+    assert "Render Docker AdGuard config" in tasks
+    assert "Hash Docker AdGuard admin password" in tasks
+    assert "apache2-utils" in tasks
+    assert "dnsutils" in tasks
+    assert "lego" in tasks
+    assert "openssl" in tasks
+    assert "adguard-acme.timer" in tasks
+    assert "renew-adguard-cert" in tasks
     assert "role: docker_engine" in site
     assert "tags: [docker_apps, docker_engine]" in site
     assert "role: docker_compose_project" in site

--- a/tests/docker/test_traefik_config.py
+++ b/tests/docker/test_traefik_config.py
@@ -20,8 +20,8 @@ def test_traefik_private_only_and_header_policies_match_caddy_contracts():
     assert "private-only" in dynamic
     assert "192.168.0.0/24" in dynamic
     assert "100.64.0.0/10" in dynamic
-    assert "adguard.home.hchu.me" in dynamic
-    assert "serverName: adguard.home.hchu.me" in dynamic
+    assert "adguard.home.hchu.me" not in dynamic
+    assert "https://192.168.0.3:443" not in dynamic
     assert "pve.home.hchu.me" in dynamic
     assert "customFrameOptionsValue: SAMEORIGIN" in dynamic
 

--- a/tests/infra/test_lxc_access_bootstrap.py
+++ b/tests/infra/test_lxc_access_bootstrap.py
@@ -52,7 +52,7 @@ def test_bootstrap_waits_for_lxc_ssh_before_using_inventory_connections():
     assert "ansible.builtin.wait_for" in playbook
     assert 'host: "{{ hostvars[item.name].ansible_host }}"' in playbook
     assert "port: 22" in playbook
-    assert "timeout: 180" in playbook
+    assert "timeout: 600" in playbook
     assert "delegate_to: localhost" in playbook
 
 


### PR DESCRIPTION
## Summary
- adds an AdGuard Home Docker Compose project under `apps/compose/dns`
- deploys Docker AdGuard through the existing `docker_apps` Compose role
- renders managed AdGuard config on the Docker host with the existing admin password secret hashed via `htpasswd`
- keeps AdGuard upstream policy on Cloudflare DNS (`tls://1.1.1.1`, `tls://1.0.0.1`) and TLS server name `adguard.home.hchu.me`
- adds host-side lego ACME renewal for AdGuard DoT/DoQ certificates under `/srv/docker-apps/adguard/tls`
- moves the Traefik `adguard.home.hchu.me` route from the old `192.168.0.3` LXC backend to Docker labels on the AdGuard Compose service
- extends Docker app validation for the `dns` Compose project and AdGuard DNS/DoT ports
- keeps the old `dns` LXC in topology for rollback; this PR does not yet reclaim `192.168.0.3` or VMID `110`

## Dependency
This branch is stacked on #112 (`fix: allow slow lxc ssh readiness`) because current `main` CD still needs the longer first-boot SSH readiness gate before Docker apps can deploy reliably.

Recommended merge order:
1. Merge #112
2. Rebase/update this PR if needed
3. Merge this DNS Docker PR

## Safety notes
- No public `dns.hchu.me` DoH route is added.
- Docker AdGuard publishes DNS `53/tcp+udp` and DoT/DoQ `853/tcp+udp` on the Docker apps host.
- AdGuard Web UI is routed privately through Traefik at `adguard.home.hchu.me`; it is not directly published.
- The old `dns` LXC remains the rollback target until Docker AdGuard is live-tested and cut over.

## Verification
- `pytest tests/docker -q`
  - `23 passed`
- `PATH=".../.venv/bin:$PATH" ANSIBLE_CONFIG=infra/ansible/ansible.cfg ./scripts/ci/validate-compose.sh`
  - `103 passed`
  - Ansible site syntax passed
  - Docker Compose config validation skipped locally because Docker Compose is unavailable here
- `ANSIBLE_CONFIG=infra/ansible/ansible.cfg ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/site.yml --syntax-check`
- `ANSIBLE_CONFIG=infra/ansible/ansible.cfg ansible-playbook -i infra/ansible/inventory/prod/hosts.yml infra/ansible/playbooks/validate.yml --syntax-check`
- isolated full pytest copy
  - `232 passed, 1 skipped`
- `python3 scripts/ci/render_ansible_inventory.py --check && python3 scripts/ci/render_ansible_targets.py`
- `for f in $(git ls-files '*.sh'); do bash -n "$f"; done`
- `tofu fmt -recursive -check ../.. && tofu validate`
- direct Jinja render smoke for `adguardhome.yaml.j2`
- `git diff --check`
