### PR TITLE
Fix pre-cutover Restic region default

### DIFF
--- a/infra/ansible/roles/pve_pre_cutover_backup/tasks/main.yml
+++ b/infra/ansible/roles/pve_pre_cutover_backup/tasks/main.yml
@@ -44,7 +44,7 @@
     RESTIC_PASSWORD: "{{ backup_restic_password }}"
     AWS_ACCESS_KEY_ID: "{{ backup_aws_access_key_id }}"
     AWS_SECRET_ACCESS_KEY: "{{ backup_aws_secret_access_key }}"
-    AWS_DEFAULT_REGION: "{{ backup_aws_default_region }}"
+    AWS_DEFAULT_REGION: "{{ backup_aws_default_region | default('auto') }}"
   register: pre_cutover_restic_probe
   changed_when: false
   failed_when: false


### PR DESCRIPTION
## What changed

Default the Proxmox-side Restic backup region to `auto` when the Docker-host group variable is not in scope.

## Why

The guarded production preflight successfully stopped legacy app LXCs and migrated shared data, but halted before Restic and before any destructive action because `backup_aws_default_region` was undefined on the Proxmox host.

## Validation

- 82 repository tests
- production failure occurred before OpenTofu plan/apply
