### PR TITLE
Keep tailnet online during cutover backup

### DIFF
--- a/infra/ansible/inventory/prod/group_vars/all.yml
+++ b/infra/ansible/inventory/prod/group_vars/all.yml
@@ -27,8 +27,8 @@ legacy_lxcs:
 
 low_id_cutover_backup_storage: local
 low_id_cutover_mappings:
-  - {target_vmid: 110, legacy_name: edge, desired_name: docker-apps, source_vmid: 117}
-  - {target_vmid: 111, legacy_name: dns, desired_name: tailnet, source_vmid: 112}
+  - {target_vmid: 110, legacy_name: edge, desired_name: docker-apps, source_vmid: 117, backup_mode: stop}
+  - {target_vmid: 111, legacy_name: dns, desired_name: tailnet, source_vmid: 112, backup_mode: snapshot}
 
 pve_lxc_root_options:
   - vmid: 111

--- a/infra/ansible/roles/pve_prepare_low_id_cutover/tasks/main.yml
+++ b/infra/ansible/roles/pve_prepare_low_id_cutover/tasks/main.yml
@@ -65,7 +65,7 @@
       - --storage
       - "{{ low_id_cutover_backup_storage }}"
       - --mode
-      - stop
+      - "{{ item.item.backup_mode }}"
       - --compress
       - zstd
       - --notes-template

--- a/tests/docker/test_docker_apps_topology.py
+++ b/tests/docker/test_docker_apps_topology.py
@@ -51,6 +51,8 @@ def test_low_id_cutover_is_hostname_guarded_and_backed_up():
     assert "legacy_name: edge" in all_vars
     assert "target_vmid: 111" in all_vars
     assert "legacy_name: dns" in all_vars
+    assert "desired_name: docker-apps, source_vmid: 117, backup_mode: stop" in all_vars
+    assert "desired_name: tailnet, source_vmid: 112, backup_mode: snapshot" in all_vars
     assert "vzdump" in tasks
     assert "      - pct\n      - destroy" in tasks
     assert "low_id_cutover_confirmed" in tasks


### PR DESCRIPTION
## What changed

Use Proxmox snapshot mode when archiving the tailnet source LXC while retaining stop mode for the Docker source.

## Why

The production preflight completed and verified the full Restic snapshot and archived Docker VMID 117. Stop-mode backup of tailnet VMID 112 then temporarily removed the GitHub runner's subnet route, stranding its SSH session. Tailnet recovered and no target VMID was destroyed.

## Validation

- 82 repository tests
- Restic pre-cutover snapshot and repository check passed in production
- Docker VMID 117 vzdump completed successfully
- tailnet peer is online after recovery
