### PR TITLE
Keep source LXCs online during low-ID cutover

### DIFF
--- a/infra/ansible/roles/pve_prepare_low_id_cutover/tasks/main.yml
+++ b/infra/ansible/roles/pve_prepare_low_id_cutover/tasks/main.yml
@@ -98,15 +98,31 @@
   changed_when: true
 
 - name: Destroy only hostname-verified legacy target occupants
-  ansible.builtin.command:
-    argv:
-      - pct
-      - destroy
-      - "{{ item.item.target_vmid | string }}"
-      - --purge
-      - "1"
-      - --destroy-unreferenced-disks
-      - "1"
+  ansible.builtin.shell: |
+    set -eu
+    vmid="{{ item.item.target_vmid }}"
+    actual_hostname="$(pct config "$vmid" | awk -F ': ' '$1 == "hostname" { print $2 }')"
+    if [ "$actual_hostname" != "{{ item.item.legacy_name }}" ]; then
+      printf 'Refusing to destroy VMID %s: expected hostname {{ item.item.legacy_name }}, found %s\n' \
+        "$vmid" "$actual_hostname" >&2
+      exit 1
+    fi
+    if pct status "$vmid" | grep -q 'status: running'; then
+      if ! pct shutdown "$vmid" --timeout 120; then
+        pct stop "$vmid"
+      fi
+    fi
+    for _ in 1 2 3 4 5 6 7 8 9 10 11 12; do
+      if pct status "$vmid" | grep -q 'status: stopped'; then
+        pct destroy "$vmid" --purge 1 --destroy-unreferenced-disks 1
+        exit 0
+      fi
+      sleep 5
+    done
+    printf 'Refusing to destroy VMID %s because it did not stop\n' "$vmid" >&2
+    exit 1
+  args:
+    executable: /bin/sh
   loop: "{{ low_id_cutover_inspection.results }}"
   loop_control:
     label: "{{ item.item.legacy_name }} ({{ item.item.target_vmid }})"

--- a/infra/opentofu/envs/prod/main.tf
+++ b/infra/opentofu/envs/prod/main.tf
@@ -1,4 +1,4 @@
-module "active_lxc" {
+module "target_lxc" {
   for_each = var.containers
 
   source = "../../modules/pve-lxc"
@@ -24,18 +24,17 @@ module "active_lxc" {
   startup_order    = each.value.startup_order
 }
 
-moved {
-  from = module.lxc["tailnet"]
-  to   = module.active_lxc["tailnet"]
+# Keep the source pair online while the lowest-ID replacements are created and
+# validated. They are retired explicitly only after the new tailnet is usable.
+removed {
+  from = module.active_lxc
+
+  lifecycle {
+    destroy = false
+  }
 }
 
-moved {
-  from = module.lxc["docker_apps"]
-  to   = module.active_lxc["docker_apps"]
-}
-
-# After the retained instances move to active_lxc, forget every legacy
-# instance left at the old module address without destroying its container.
+# Forget every earlier legacy instance without destroying its container.
 removed {
   from = module.lxc
 

--- a/infra/opentofu/envs/prod/outputs.tf
+++ b/infra/opentofu/envs/prod/outputs.tf
@@ -1,6 +1,6 @@
 output "containers" {
   value = {
-    for name, container in module.active_lxc : name => {
+    for name, container in module.target_lxc : name => {
       vmid     = container.vmid
       hostname = container.hostname
       ipv4     = container.ipv4

--- a/scripts/ci/check_tofu_plan_safe.py
+++ b/scripts/ci/check_tofu_plan_safe.py
@@ -12,9 +12,9 @@ from typing import Any
 from homelab_topology import expected_lxc_count
 
 LXC_RESOURCE_SUFFIX = ".proxmox_virtual_environment_container.this"
-APPROVED_LOW_ID_RENUMBER = {
-    f'module.active_lxc["docker_apps"]{LXC_RESOURCE_SUFFIX}': (117, 110),
-    f'module.active_lxc["tailnet"]{LXC_RESOURCE_SUFFIX}': (112, 111),
+APPROVED_LOW_ID_TARGETS = {
+    f'module.target_lxc["docker_apps"]{LXC_RESOURCE_SUFFIX}': 110,
+    f'module.target_lxc["tailnet"]{LXC_RESOURCE_SUFFIX}': 111,
 }
 
 
@@ -41,26 +41,22 @@ def _actions(resource: dict[str, Any]) -> list[str]:
     return list(resource.get("change", {}).get("actions", []))
 
 
-def _is_approved_low_id_renumber(resource: dict[str, Any]) -> bool:
+def _is_approved_low_id_target(resource: dict[str, Any]) -> bool:
     address = resource.get("address", "")
-    expected = APPROVED_LOW_ID_RENUMBER.get(address)
-    if expected is None or _actions(resource) not in (
-        ["delete", "create"],
-        ["create", "delete"],
-    ):
+    expected = APPROVED_LOW_ID_TARGETS.get(address)
+    if expected is None or _actions(resource) != ["create"]:
         return False
 
     change = resource.get("change", {})
-    before_vmid = (change.get("before") or {}).get("vm_id")
     after_vmid = (change.get("after") or {}).get("vm_id")
-    return (before_vmid, after_vmid) == expected
+    return after_vmid == expected
 
 
 def _destructive_changes(plan: dict[str, Any]) -> list[str]:
     destructive = []
     for resource in _resource_changes(plan):
         actions = _actions(resource)
-        if "delete" in actions and not _is_approved_low_id_renumber(resource):
+        if "delete" in actions:
             address = resource.get("address", "<unknown>")
             destructive.append(f"{address}: {','.join(actions)}")
     return destructive
@@ -70,7 +66,7 @@ def _create_only_lxc_changes(plan: dict[str, Any]) -> list[str]:
     create_only = []
     for resource in _resource_changes(plan):
         address = resource.get("address", "")
-        if not address.startswith("module.active_lxc[") or not address.endswith(LXC_RESOURCE_SUFFIX):
+        if not address.startswith("module.target_lxc[") or not address.endswith(LXC_RESOURCE_SUFFIX):
             continue
         if _actions(resource) == ["create"]:
             create_only.append(address)
@@ -86,10 +82,10 @@ def _expected_lxc_count() -> int:
 
 def main(argv: list[str]) -> int:
     plan = _load_plan(argv)
-    approved_renumbers = [
+    approved_targets = [
         resource.get("address", "<unknown>")
         for resource in _resource_changes(plan)
-        if _is_approved_low_id_renumber(resource)
+        if _is_approved_low_id_target(resource)
     ]
     destructive = _destructive_changes(plan)
 
@@ -109,17 +105,33 @@ def main(argv: list[str]) -> int:
         )
         return 1
 
-    for address in approved_renumbers:
-        old_vmid, new_vmid = APPROVED_LOW_ID_RENUMBER[address]
-        print(f"Approved one-time low-ID renumber: {address} {old_vmid} -> {new_vmid}.")
+    for address in approved_targets:
+        vmid = APPROVED_LOW_ID_TARGETS[address]
+        print(f"Approved one-time retained-source low-ID target: {address} -> {vmid}.")
 
     create_only_lxcs = _create_only_lxc_changes(plan)
+    invalid_known_targets = [
+        resource.get("address", "<unknown>")
+        for resource in _resource_changes(plan)
+        if resource.get("address") in APPROVED_LOW_ID_TARGETS
+        and _actions(resource) == ["create"]
+        and not _is_approved_low_id_target(resource)
+    ]
+    if invalid_known_targets:
+        print("OpenTofu plan uses an unexpected VMID for a protected low-ID target:", file=sys.stderr)
+        for address in invalid_known_targets:
+            print(f"- {address}: expected VMID {APPROVED_LOW_ID_TARGETS[address]}", file=sys.stderr)
+        return 1
+
+    unapproved_create_only_lxcs = [
+        address for address in create_only_lxcs if address not in APPROVED_LOW_ID_TARGETS
+    ]
     expected_lxcs = _expected_lxc_count()
-    if len(create_only_lxcs) >= expected_lxcs and not _truthy(
+    if len(unapproved_create_only_lxcs) >= expected_lxcs and not _truthy(
         os.environ.get("ALLOW_EMPTY_STATE_BOOTSTRAP")
     ):
         print("OpenTofu plan appears to be a create-only LXC bootstrap plan:", file=sys.stderr)
-        for address in create_only_lxcs:
+        for address in unapproved_create_only_lxcs:
             print(f"- {address}: create-only", file=sys.stderr)
         print(
             "Refusing to continue because this often means the production remote state "

--- a/tests/docker/test_docker_apps_topology.py
+++ b/tests/docker/test_docker_apps_topology.py
@@ -24,11 +24,10 @@ def test_only_tailnet_and_docker_apps_are_managed_lxcs():
 
 def test_retired_lxcs_are_forgotten_without_destruction():
     main = read("infra/opentofu/envs/prod/main.tf")
-    assert 'from = module.lxc["tailnet"]' in main
-    assert 'to   = module.active_lxc["tailnet"]' in main
-    assert 'from = module.lxc["docker_apps"]' in main
+    assert 'module "target_lxc"' in main
+    assert "from = module.active_lxc\n" in main
     assert "from = module.lxc\n" in main
-    assert main.count("destroy = false") == 1
+    assert main.count("destroy = false") == 2
 
 
 def test_docker_lxc_gets_tun_and_one_data_root_mount():
@@ -54,7 +53,9 @@ def test_low_id_cutover_is_hostname_guarded_and_backed_up():
     assert "desired_name: docker-apps, source_vmid: 117, backup_mode: stop" in all_vars
     assert "desired_name: tailnet, source_vmid: 112, backup_mode: snapshot" in all_vars
     assert "vzdump" in tasks
-    assert "      - pct\n      - destroy" in tasks
+    assert "pct shutdown" in tasks
+    assert "status: stopped" in tasks
+    assert 'pct destroy "$vmid"' in tasks
     assert "low_id_cutover_confirmed" in tasks
     assert "low_id_data_backup_confirmed" in tasks
     assert playbook.index("pve_retire_legacy_lxcs") < playbook.index("pve_homelab_storage")

--- a/tests/repo/test_github_workflows.py
+++ b/tests/repo/test_github_workflows.py
@@ -196,9 +196,9 @@ def test_tofu_apply_is_guarded_against_destroying_lxcs():
     assert "prevent_destroy = true" not in module
     assert "tofu show -json prod.tfplan" in plan_script
     assert "check_tofu_plan_safe.py" in plan_script
-    assert "APPROVED_LOW_ID_RENUMBER" in guard_script
-    assert "(117, 110)" in guard_script
-    assert "(112, 111)" in guard_script
+    assert "APPROVED_LOW_ID_TARGETS" in guard_script
+    assert "docker_apps" in guard_script and ": 110" in guard_script
+    assert "tailnet" in guard_script and ": 111" in guard_script
     assert "ALLOW_TOFU_DESTROY" in guard_script
     assert "ALLOW_EMPTY_STATE_BOOTSTRAP" in guard_script
     assert '"delete" in actions' in guard_script

--- a/tests/repo/test_tofu_plan_guard.py
+++ b/tests/repo/test_tofu_plan_guard.py
@@ -40,23 +40,21 @@ def test_tofu_plan_guard_accepts_non_destructive_changes():
     assert "no unapproved destructive actions" in result.stdout
 
 
-def test_tofu_plan_guard_allows_only_exact_low_id_renumbers():
+def test_tofu_plan_guard_allows_only_exact_retained_source_low_id_targets():
     result = run_guard(
         {
             "resource_changes": [
                 {
-                    "address": 'module.active_lxc["docker_apps"].proxmox_virtual_environment_container.this',
+                    "address": 'module.target_lxc["docker_apps"].proxmox_virtual_environment_container.this',
                     "change": {
-                        "actions": ["delete", "create"],
-                        "before": {"vm_id": 117},
+                        "actions": ["create"],
                         "after": {"vm_id": 110},
                     },
                 },
                 {
-                    "address": 'module.active_lxc["tailnet"].proxmox_virtual_environment_container.this',
+                    "address": 'module.target_lxc["tailnet"].proxmox_virtual_environment_container.this',
                     "change": {
-                        "actions": ["delete", "create"],
-                        "before": {"vm_id": 112},
+                        "actions": ["create"],
                         "after": {"vm_id": 111},
                     },
                 },
@@ -65,19 +63,18 @@ def test_tofu_plan_guard_allows_only_exact_low_id_renumbers():
     )
 
     assert result.returncode == 0
-    assert "117 -> 110" in result.stdout
-    assert "112 -> 111" in result.stdout
+    assert "-> 110" in result.stdout
+    assert "-> 111" in result.stdout
 
 
-def test_tofu_plan_guard_rejects_almost_matching_renumber():
+def test_tofu_plan_guard_rejects_almost_matching_low_id_target():
     result = run_guard(
         {
             "resource_changes": [
                 {
-                    "address": 'module.active_lxc["docker_apps"].proxmox_virtual_environment_container.this',
+                    "address": 'module.target_lxc["docker_apps"].proxmox_virtual_environment_container.this',
                     "change": {
-                        "actions": ["delete", "create"],
-                        "before": {"vm_id": 117},
+                        "actions": ["create"],
                         "after": {"vm_id": 109},
                     },
                 }
@@ -86,7 +83,7 @@ def test_tofu_plan_guard_rejects_almost_matching_renumber():
     )
 
     assert result.returncode == 1
-    assert "ALLOW_TOFU_DESTROY" in result.stderr
+    assert "expected VMID 110" in result.stderr
 
 
 def test_tofu_plan_guard_rejects_delete_actions_by_default():
@@ -128,7 +125,7 @@ def test_tofu_plan_guard_rejects_create_only_lxc_plan_by_default():
         {
             "resource_changes": [
                 {
-                    "address": f"module.active_lxc[\"svc{i}\"].proxmox_virtual_environment_container.this",
+                    "address": f"module.target_lxc[\"svc{i}\"].proxmox_virtual_environment_container.this",
                     "change": {"actions": ["create"]},
                 }
                 for i in range(expected_lxc_count())
@@ -150,7 +147,7 @@ def test_tofu_plan_guard_allows_create_only_lxc_plan_for_explicit_bootstrap():
             {
                 "resource_changes": [
                     {
-                        "address": f"module.active_lxc[\"svc{i}\"].proxmox_virtual_environment_container.this",
+                        "address": f"module.target_lxc[\"svc{i}\"].proxmox_virtual_environment_container.this",
                         "change": {"actions": ["create"]},
                     }
                     for i in range(expected_lxc_count())


### PR DESCRIPTION
Creates VMIDs 110/111 at new OpenTofu addresses while forgetting—but not destroying—the live source pair 117/112. Also rechecks hostname, gracefully stops, verifies stopped state, and only then destroys legacy occupants of the target IDs. This prevents the tailnet route from disappearing mid-apply.\n\nVerified: 82 tests pass; git diff --check passes.