### PR TITLE
Configure static LXC DNS before package bootstrap

### DIFF
--- a/infra/ansible/roles/pve_lxc_access_bootstrap/tasks/main.yml
+++ b/infra/ansible/roles/pve_lxc_access_bootstrap/tasks/main.yml
@@ -36,10 +36,33 @@
         '
         ;;
       debian)
-        pct exec "${vmid}" -- /bin/bash -lc '
+        nameservers="$(pct config "${vmid}" | awk -F ': ' '$1 == "nameserver" { print $2 }')"
+        if [ -z "${nameservers}" ]; then
+          printf "No Proxmox nameservers configured for VMID %s\n" "${vmid}" >&2
+          exit 1
+        fi
+        pct exec "${vmid}" -- /usr/bin/env \
+          HOMELAB_NAMESERVERS="${nameservers}" \
+          HOMELAB_SEARCH_DOMAIN="{{ homelab_private_domain }}" \
+          /bin/bash -lc '
           set -eu
           changed=0
           export DEBIAN_FRONTEND=noninteractive
+
+          expected_resolver="$(
+            printf "# --- BEGIN PVE ---\nsearch %s\n" "${HOMELAB_SEARCH_DOMAIN}"
+            for nameserver in ${HOMELAB_NAMESERVERS}; do
+              printf "nameserver %s\n" "${nameserver}"
+            done
+            printf "# --- END PVE ---"
+          )"
+          current_resolver="$(cat /etc/resolv.conf 2>/dev/null || true)"
+          if [ "${current_resolver}" != "${expected_resolver}" ]; then
+            rm -f /etc/resolv.conf
+            printf "%s\n" "${expected_resolver}" > /etc/resolv.conf
+            changed=1
+          fi
+
           missing=0
           for pkg in openssh-server python3; do
             if ! dpkg -s "${pkg}" >/dev/null 2>&1; then

--- a/tests/docker/test_docker_apps_topology.py
+++ b/tests/docker/test_docker_apps_topology.py
@@ -40,6 +40,16 @@ def test_docker_lxc_gets_tun_and_one_data_root_mount():
     assert "-mp1" not in docker
 
 
+def test_debian_bootstrap_materializes_proxmox_dns_before_apt():
+    tasks = read("infra/ansible/roles/pve_lxc_access_bootstrap/tasks/main.yml")
+
+    dns = tasks.index('nameservers="$(pct config')
+    resolver = tasks.index("rm -f /etc/resolv.conf")
+    apt = tasks.index("apt-get update", resolver)
+    assert dns < resolver < apt
+    assert "HOMELAB_SEARCH_DOMAIN" in tasks
+
+
 def test_low_id_cutover_is_hostname_guarded_and_backed_up():
     all_vars = read("infra/ansible/inventory/prod/group_vars/all.yml")
     tasks = read("infra/ansible/roles/pve_prepare_low_id_cutover/tasks/main.yml")


### PR DESCRIPTION
Materializes the Proxmox-configured nameservers and homelab search domain inside fresh Debian LXCs before the first apt operation. This fixes fresh systemd-resolved images whose resolv.conf reports no known DNS servers.\n\nLive verification: apt-get update succeeds on VMID 110 after applying the same resolver content. Automated verification: 84 tests pass; git diff --check passes.