### PR TITLE
Pin valid Hermes image and stabilize tailnet DERP

### DIFF
--- a/apps/compose/hermes/Dockerfile
+++ b/apps/compose/hermes/Dockerfile
@@ -1,4 +1,4 @@
-FROM nousresearch/hermes-agent:v0.18.2
+FROM nousresearch/hermes-agent:v2026.7.7.2@sha256:9c841866021c54c4596849f6135717e8a4d52ba510b7f52c50aef1de1a283973
 
 USER root
 

--- a/apps/compose/hermes/compose.yml
+++ b/apps/compose/hermes/compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: homelab/hermes-agent:0.18.2
+    image: homelab/hermes-agent:2026.7.7.2
     container_name: hermes
     restart: unless-stopped
     command: ["gateway", "run"]
@@ -25,4 +25,3 @@ services:
         limits:
           memory: 4G
           cpus: "2.0"
-

--- a/infra/ansible/roles/tailscale_gateway/handlers/main.yml
+++ b/infra/ansible/roles/tailscale_gateway/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Restart tailscaled after underlay change
+  ansible.builtin.systemd:
+    name: tailscaled
+    state: restarted

--- a/infra/ansible/roles/tailscale_gateway/tasks/main.yml
+++ b/infra/ansible/roles/tailscale_gateway/tasks/main.yml
@@ -18,17 +18,26 @@
     update_cache: true
     state: present
 
+- name: Disable unusable public IPv6 underlay for stable DERP selection
+  ansible.builtin.copy:
+    dest: /etc/sysctl.d/90-homelab-ipv4-underlay.conf
+    mode: "0644"
+    content: |
+      net.ipv6.conf.all.disable_ipv6=1
+      net.ipv6.conf.default.disable_ipv6=1
+      net.ipv6.conf.lo.disable_ipv6=1
+  notify: Restart tailscaled after underlay change
+
 - name: Enable IPv4 forwarding
   ansible.builtin.copy:
     dest: /etc/sysctl.d/99-tailscale-subnet-router.conf
     mode: "0644"
     content: |
       net.ipv4.ip_forward=1
-      net.ipv6.conf.all.forwarding=1
 
 - name: Apply sysctl
   ansible.builtin.command:
-    cmd: sysctl -w net.ipv4.ip_forward=1 net.ipv6.conf.all.forwarding=1
+    cmd: sysctl --system
   changed_when: false
 
 - name: Enable tailscaled
@@ -50,3 +59,6 @@
   no_log: true
   when: tailscale_auth_key is defined
   changed_when: false
+
+- name: Apply pending Tailscale underlay restart before validation
+  ansible.builtin.meta: flush_handlers

--- a/tests/docker/test_hermes_compose.py
+++ b/tests/docker/test_hermes_compose.py
@@ -5,11 +5,11 @@ def test_hermes_uses_official_image_persistent_mounts_and_no_docker_socket():
     compose = (REPO_ROOT / "apps/compose/hermes/compose.yml").read_text(encoding="utf-8")
     dockerfile = (REPO_ROOT / "apps/compose/hermes/Dockerfile").read_text(encoding="utf-8")
 
-    assert "FROM nousresearch/hermes-agent:v0.18.2" in dockerfile
+    assert "FROM nousresearch/hermes-agent:v2026.7.7.2@sha256:" in dockerfile
+    assert "image: homelab/hermes-agent:2026.7.7.2" in compose
     assert "1password-cli" in dockerfile
     assert 'command: ["gateway", "run"]' in compose
     assert "/srv/homelab/hermes/home:/opt/data:rw" in compose
     assert "/srv/homelab/hermes/workspace:/workspace:rw" in compose
     assert "shm_size: 1gb" in compose
     assert "/var/run/docker.sock" not in compose
-

--- a/tests/tailnet/test_tailscale_gateway_role.py
+++ b/tests/tailnet/test_tailscale_gateway_role.py
@@ -23,3 +23,20 @@ def test_tailnet_lxc_disables_tailscale_dns_acceptance():
 
     assert "tailscale_accept_dns: false" in inventory
     assert "--accept-dns={{ tailscale_accept_dns | default(false) | lower }}" in role
+
+
+def test_tailnet_uses_ipv4_only_underlay_when_public_ipv6_is_unroutable():
+    role = (
+        REPO_ROOT
+        / "infra"
+        / "ansible"
+        / "roles"
+        / "tailscale_gateway"
+        / "tasks"
+        / "main.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "net.ipv6.conf.all.disable_ipv6=1" in role
+    assert "net.ipv6.conf.default.disable_ipv6=1" in role
+    assert "sysctl --system" in role
+    assert "net.ipv6.conf.all.forwarding=1" not in role


### PR DESCRIPTION
Pins the current official Hermes Agent v2026.7.7.2 multi-arch image by OCI digest, replacing the nonexistent v0.18.2 tag. Also makes the IPv4-only homelab underlay explicit so Tailscale no longer repeatedly selects unreachable public IPv6 DERP endpoints.\n\nLive verification: the pinned manifest resolves from VMID 110; VMID 111 reports IPv6 disabled and stable IPv4 DERP connectivity. Automated verification: 85 tests pass; git diff --check passes.