### PR TITLE
Fix AdGuard and Gluetun runtime health

### DIFF
--- a/apps/compose/media/compose.yml
+++ b/apps/compose/media/compose.yml
@@ -12,6 +12,8 @@ services:
     environment:
       VPN_PORT_FORWARDING: "on"
       PORT_FORWARD_ONLY: "on"
+      HEALTH_SMALL_CHECK_TYPE: dns
+      HEALTH_TARGET_ADDRESSES: "cloudflare.com:443,github.com:443"
       FIREWALL_INPUT_PORTS: "8080"
       FIREWALL_OUTBOUND_SUBNETS: "192.168.0.0/24,100.64.0.0/10"
       VPN_PORT_FORWARDING_UP_COMMAND: >-

--- a/apps/compose/platform/compose.yml
+++ b/apps/compose/platform/compose.yml
@@ -32,7 +32,7 @@ services:
     restart: unless-stopped
     network_mode: host
     volumes:
-      - ./AdGuardHome.yaml:/opt/adguardhome/conf/AdGuardHome.yaml:rw
+      - ./adguard:/opt/adguardhome/conf:rw
       - adguard_work:/opt/adguardhome/work
     healthcheck:
       test: ["CMD", "/opt/adguardhome/AdGuardHome", "--check-config", "-c", "/opt/adguardhome/conf/AdGuardHome.yaml"]

--- a/infra/ansible/inventory/prod/group_vars/svc_docker_apps.yml
+++ b/infra/ansible/inventory/prod/group_vars/svc_docker_apps.yml
@@ -60,7 +60,7 @@ docker_compose_projects:
     env_template: platform.env.j2
     config_templates:
       - src: AdGuardHome.yaml.j2
-        dest: AdGuardHome.yaml
+        dest: adguard/AdGuardHome.yaml
         mode: "0600"
   - name: media
     src: apps/compose/media

--- a/infra/ansible/roles/docker_compose_project/tasks/main.yml
+++ b/infra/ansible/roles/docker_compose_project/tasks/main.yml
@@ -74,6 +74,7 @@
     mode: "{{ item.mode | default('0755') }}"
   loop:
     - {path: "{{ docker_apps_compose_root }}", owner: root, group: root}
+    - {path: "{{ docker_apps_compose_root }}/platform/adguard", owner: root, group: root, mode: "0750"}
     - {path: /srv/homelab/docker-apps/qbittorrent/qBittorrent, mode: "0700"}
     - {path: /srv/homelab/docker-apps/copyparty}
     - {path: /srv/homelab/downloads/complete}
@@ -127,7 +128,7 @@
                             print(candidate.split(":", 1)[1].strip().strip('"'))
                             raise SystemExit(0)
         print("")
-      - "{{ docker_apps_compose_root }}/platform/AdGuardHome.yaml"
+      - "{{ docker_apps_compose_root }}/platform/adguard/AdGuardHome.yaml"
       - "{{ adguard_admin_username }}"
   register: adguard_existing_admin_hash
   changed_when: false

--- a/tests/docker/test_media_compose.py
+++ b/tests/docker/test_media_compose.py
@@ -10,6 +10,8 @@ def test_qbittorrent_uses_gluetun_namespace_and_native_port_forwarding():
     assert "ports:" not in qbittorrent
     assert 'VPN_PORT_FORWARDING: "on"' in gluetun
     assert 'PORT_FORWARD_ONLY: "on"' in gluetun
+    assert "HEALTH_SMALL_CHECK_TYPE: dns" in gluetun
+    assert 'HEALTH_TARGET_ADDRESSES: "cloudflare.com:443,github.com:443"' in gluetun
     assert "VPN_PORT_FORWARDING_UP_COMMAND" in gluetun
     assert "/api/v2/app/setPreferences" in gluetun
 

--- a/tests/docker/test_traefik_config.py
+++ b/tests/docker/test_traefik_config.py
@@ -36,6 +36,8 @@ def test_adguard_uses_host_network_only_for_plain_dns_and_private_admin():
     ).read_text(encoding="utf-8")
 
     assert "network_mode: host" in compose
+    assert "./adguard:/opt/adguardhome/conf:rw" in compose
+    assert "./AdGuardHome.yaml:/opt/adguardhome/conf/AdGuardHome.yaml" not in compose
     assert "port: {{ adguard_dns_port }}" in template
     assert "address: 0.0.0.0:{{ adguard_admin_port }}" in template
     assert "enabled: false" in template.split("tls:", 1)[1]


### PR DESCRIPTION
Mounts the AdGuard config directory so AdGuard can atomically rewrite its YAML instead of failing with EBUSY on a file bind mount. Configures Gluetun's small periodic check to use DNS, since the working Proton endpoint blocks ICMP; live DNS and VPN egress were verified from the container.\n\nVerified: 85 tests pass; git diff --check passes.