### PR TITLE
Apply only LXC-owned tailnet sysctls

### DIFF
--- a/infra/ansible/roles/tailscale_gateway/tasks/main.yml
+++ b/infra/ansible/roles/tailscale_gateway/tasks/main.yml
@@ -37,7 +37,12 @@
 
 - name: Apply sysctl
   ansible.builtin.command:
-    cmd: sysctl --system
+    cmd: >-
+      sysctl -w
+      net.ipv6.conf.all.disable_ipv6=1
+      net.ipv6.conf.default.disable_ipv6=1
+      net.ipv6.conf.lo.disable_ipv6=1
+      net.ipv4.ip_forward=1
   changed_when: false
 
 - name: Enable tailscaled

--- a/tests/tailnet/test_tailscale_gateway_role.py
+++ b/tests/tailnet/test_tailscale_gateway_role.py
@@ -38,5 +38,6 @@ def test_tailnet_uses_ipv4_only_underlay_when_public_ipv6_is_unroutable():
 
     assert "net.ipv6.conf.all.disable_ipv6=1" in role
     assert "net.ipv6.conf.default.disable_ipv6=1" in role
-    assert "sysctl --system" in role
+    assert "sysctl -w" in role
+    assert "net.ipv4.ip_forward=1" in role
     assert "net.ipv6.conf.all.forwarding=1" not in role


### PR DESCRIPTION
Avoids sysctl --system inside the unprivileged tailnet LXC, which correctly applies our settings but returns failure for unrelated host-owned kernel keys. Applies only the three IPv6-underlay disable keys and IPv4 forwarding.\n\nLive verification: exact command returns zero on VMID 111. Automated verification: 85 tests pass; git diff --check passes.