### PR TITLE
Retry transient Restic repository validation

### DIFF
--- a/infra/ansible/playbooks/validate.yml
+++ b/infra/ansible/playbooks/validate.yml
@@ -176,5 +176,9 @@
       ansible.builtin.command:
         cmd: docker compose exec -T restic-backup restic cat config
         chdir: "{{ docker_apps_compose_root }}/backup"
+      register: restic_repository_access
+      retries: 6
+      delay: 10
+      until: restic_repository_access.rc == 0
       changed_when: false
       no_log: true

--- a/tests/docker/test_backup_compose.py
+++ b/tests/docker/test_backup_compose.py
@@ -1,6 +1,15 @@
 from tests.helpers import REPO_ROOT
 
 
+def test_restic_repository_validation_retries_transient_remote_errors():
+    validation = (REPO_ROOT / "infra/ansible/playbooks/validate.yml").read_text(encoding="utf-8")
+    restic = validation.split("- name: Check Restic repository access", 1)[1]
+
+    assert "retries: 6" in restic
+    assert "delay: 10" in restic
+    assert "until: restic_repository_access.rc == 0" in restic
+
+
 def test_backup_covers_qbittorrent_downloads_and_copyparty_read_only():
     compose = (REPO_ROOT / "apps/compose/backup/compose.yml").read_text(encoding="utf-8")
     script = (REPO_ROOT / "apps/compose/backup/backup-loop.sh").read_text(encoding="utf-8")
@@ -26,4 +35,3 @@ def test_cd_requires_encrypted_off_host_backup_credentials():
     ):
         assert name in workflow
         assert name in writer
-


### PR DESCRIPTION
Retries the external Restic repository config read for up to one minute after Compose restart. The live container succeeded on the immediate manual retry and returned the expected repository config.

Verified: 86 tests pass; git diff --check passes.