### PR TITLE
Allow AdGuard to normalize release config

### DIFF
--- a/apps/compose/homelab/compose.yml
+++ b/apps/compose/homelab/compose.yml
@@ -33,7 +33,9 @@ services:
     restart: unless-stopped
     network_mode: host
     volumes:
-      - ./generated/adguard/AdGuardHome.yaml:/opt/adguardhome/conf/AdGuardHome.yaml:ro
+      # AdGuard persists normalized runtime fields back into its config file.
+      # The slot is rebuilt from the declarative package on every release/audit.
+      - ./generated/adguard:/opt/adguardhome/conf:rw
       - adguard_work:/opt/adguardhome/work
     labels:
       - homelab.smoke.url=https://adguard.home.hchu.me/

--- a/tests/docker/test_homelab_compose.py
+++ b/tests/docker/test_homelab_compose.py
@@ -106,6 +106,12 @@ def test_secret_inputs_and_smoke_endpoints_are_package_local(model):
     assert "adguard" in smoked
 
 
+def test_adguard_can_persist_runtime_normalization_in_the_rebuilt_slot(model):
+    mounts = model["services"]["adguard"]["volumes"]
+    assert "./generated/adguard:/opt/adguardhome/conf:rw" in mounts
+    assert not any("AdGuardHome.yaml" in mount for mount in mounts)
+
+
 def test_real_compose_render_accepts_one_prepared_package(tmp_path):
     docker = shutil.which("docker")
     if docker is None:

--- a/tests/docker/test_traefik_config.py
+++ b/tests/docker/test_traefik_config.py
@@ -54,7 +54,7 @@ def test_adguard_static_policy_is_package_owned_and_plain_dns_only():
 
     assert service["network_mode"] == "host"
     assert (
-        "./generated/adguard/AdGuardHome.yaml:/opt/adguardhome/conf/AdGuardHome.yaml:ro"
+        "./generated/adguard:/opt/adguardhome/conf:rw"
         in service["volumes"]
     )
     assert template["dns"]["port"] == 53


### PR DESCRIPTION
## Cause
The first production activation correctly rolled back because AdGuard restarts when its config file is mounted read-only; AdGuard persists normalized runtime fields during startup.

## Fix
Mount the regenerated slot-local config directory read-write. The immutable source package remains unchanged, and every deploy/audit rebuilds the runtime slot from the component bundle.

## Verification
- focused tests: 15 passed, 1 skipped
- Apps Compose validation passed
- production activation rehearsal: all 6 services healthy and semantic smoke passed
- exact legacy stack restored and smoke passed after rehearsal